### PR TITLE
Add Aflami preview and Aflami theme

### DIFF
--- a/designSystem/build.gradle.kts
+++ b/designSystem/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.ui.tooling.preview.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/designSystem/src/main/java/com/example/designsystem/theme/AflamiTheme.kt
+++ b/designSystem/src/main/java/com/example/designsystem/theme/AflamiTheme.kt
@@ -1,0 +1,28 @@
+package com.example.designsystem.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import com.amsterdam.aflami.darkThemeColors
+import com.amsterdam.aflami.lightThemeColors
+import com.amsterdam.aflami.localAflamiAppColors
+
+@Composable
+fun AflamiTheme(
+    isDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val theme = if (isDarkTheme) darkThemeColors else lightThemeColors
+
+    CompositionLocalProvider(
+        localAflamiAppColors provides theme,
+        LocalIsDarkTheme provides isDarkTheme
+    ) {
+        content()
+    }
+}
+
+internal val LocalIsDarkTheme = compositionLocalOf<Boolean> {
+    error("LocalIsDarkTheme not provided")
+}

--- a/designSystem/src/main/java/com/example/designsystem/theme/AflamiTheme.kt
+++ b/designSystem/src/main/java/com/example/designsystem/theme/AflamiTheme.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
-import com.amsterdam.aflami.darkThemeColors
-import com.amsterdam.aflami.lightThemeColors
-import com.amsterdam.aflami.localAflamiAppColors
+import com.example.designsystem.theme.colors.darkThemeColors
+import com.example.designsystem.theme.colors.lightThemeColors
+import com.example.designsystem.theme.colors.localAflamiAppColors
 
 @Composable
 fun AflamiTheme(

--- a/designSystem/src/main/java/com/example/designsystem/theme/AppTheme.kt
+++ b/designSystem/src/main/java/com/example/designsystem/theme/AppTheme.kt
@@ -2,20 +2,17 @@ package com.example.designsystem.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.ui.graphics.Color
 import com.example.designsystem.theme.colors.AflamiColorScheme
 import com.example.designsystem.theme.colors.localAflamiAppColors
 import com.example.designsystem.theme.textStyle.AflamiTextStyle
 import com.example.designsystem.theme.textStyle.LocalAflamiTextStyle
 
-typealias ColorType = @Composable () -> Color
+object AppTheme {
 
-object AppTheme{
     val color: AflamiColorScheme
-    @Composable @ReadOnlyComposable get() = localAflamiAppColors.current
+        @Composable @ReadOnlyComposable get() = localAflamiAppColors.current
 
     val textStyle: AflamiTextStyle
-    @Composable @ReadOnlyComposable get() = LocalAflamiTextStyle.current
-//  val images: AflamiAppImages
-//      @Composable @ReadOnlyComposable get() = LocalAflamiLocalImages.current
+        @Composable @ReadOnlyComposable get() = LocalAflamiTextStyle.current
+
 }

--- a/designSystem/src/main/java/com/example/designsystem/utils/AflamiPreview.kt
+++ b/designSystem/src/main/java/com/example/designsystem/utils/AflamiPreview.kt
@@ -1,0 +1,34 @@
+package com.example.designsystem.utils
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "Light Theme - English",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    locale = "en",
+)
+@Preview(
+    name = "Dark Theme - English",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    locale = "en",
+)
+@Preview(
+    name = "Light Theme - Arabic",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    locale = "ar",
+)
+@Preview(
+    name = "Dark Theme - Arabic",
+    group = "Themes and Locales",
+    showBackground = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    locale = "ar",
+)
+annotation class ThemeAndLocalePreviews

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ googleService = "4.4.3"
 firebaseCrashlytics = "3.0.4"
 firebasePreferences = "1.4.2"
 ksp = "2.0.21-1.0.27"
+uiToolingPreviewAndroid = "1.8.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -61,6 +62,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 
 
 [plugins]


### PR DESCRIPTION

## Description
Add locale and theme preview and add Aflami theme that will wrap our content inside
---

## Changes Made
List the changes introduced in this pull request:

- Add locale and theme preview --> ThemeAndLocalePreviews
- Add Aflami theme that will wrap our content inside to use the correct colors based on a Boolean passed if we are on light or dark theme --> AflamiTheme

---

## Screenshots (if applicable)
How to use:

![image](https://github.com/user-attachments/assets/db5d4dd1-28fe-40fb-a8b5-4dc69050ffca)

---

## Checklist

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
