### PR TITLE
Add Pull Request Write Permission Access

### DIFF
--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -8,6 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull_request_workflow.yml
+++ b/.github/workflows/pull_request_workflow.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           paths: |
             build/reports/jacoco/test/jacocoTestReport.xml
-          token: ${{ secrets.CI_GITHUB_TOKEN }}  
+          token: ${{ secrets.GITHUB_TOKEN }}  
           min-coverage-overall: 80
           min-coverage-changed-files: 80
           update-comment: true


### PR DESCRIPTION
## Description
The pull request workflow now has `pull-requests: write` permissions. This allows the workflow to, for example, add comments to pull requests. Read permissions for contents are also explicitly set.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---