### PR TITLE
Add Custom Excpetions and Refactor Base View Model

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -12,7 +12,9 @@ kotlin {
     }
 }
 dependencies {
-    implementation(project(":entity"))
+
+    api(project(":entity"))
+
     implementation(libs.kotlinx.coroutines.core)
     implementation (libs.kotlinx.coroutines.android)
 }

--- a/domain/src/main/java/com/example/domain/exceptions/AflamiException.kt
+++ b/domain/src/main/java/com/example/domain/exceptions/AflamiException.kt
@@ -1,4 +1,4 @@
-package com.example.domain.utils
+package com.example.domain.exceptions
 
 open class AflamiException : Exception()
 

--- a/domain/src/main/java/com/example/domain/utils/AflamiException.kt
+++ b/domain/src/main/java/com/example/domain/utils/AflamiException.kt
@@ -1,0 +1,12 @@
+package com.example.domain.utils
+
+open class AflamiException : Exception()
+
+open class QueryValidationException() : AflamiException()
+
+class QueryTooShortException : QueryValidationException()
+class QueryTooLongException : QueryValidationException()
+class InvalidCharactersException : QueryValidationException()
+class BlankQueryException : QueryValidationException()
+
+class UnknownException : AflamiException()

--- a/viewModel/build.gradle.kts
+++ b/viewModel/build.gradle.kts
@@ -9,7 +9,11 @@ android {
 }
 
 dependencies {
+
+    api(project(":domain"))
+
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.appcompat)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/viewModel/src/main/java/com/example/viewmodel/BaseViewModel.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/BaseViewModel.kt
@@ -2,8 +2,8 @@ package com.example.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.domain.utils.AflamiException
-import com.example.domain.utils.UnknownException
+import com.example.domain.exceptions.AflamiException
+import com.example.domain.exceptions.UnknownException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow


### PR DESCRIPTION
## Description
add custom exceptions

---

## Changes Made
- viewModel module now uses `api` for `:domain` dependency.
- domain module now uses `api` for `:entity` dependency.
- Introducing a sealed class `AflamiException` to represent specific domain errors. This allows for more granular error handling and reporting.
- Modifying the `tryToExecute` function to catch `AflamiException` and provide it to the `onError` callback.
- Ensuring that any other unexpected exceptions are caught and wrapped as an `UnknownException`.
- Removing the `inScope` parameter and the return type from `tryToExecute` as the coroutine is now always launched in `viewModelScope`.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.