### PR TITLE
fix: enable Apply button in FilterDialog based on filter data

### DIFF
--- a/ui/src/main/java/com/example/ui/screens/search/sections/FilterDialog.kt
+++ b/ui/src/main/java/com/example/ui/screens/search/sections/FilterDialog.kt
@@ -125,7 +125,7 @@ fun FilterDialog(
             PrimaryButton(
                 title = stringResource(R.string.apply),
                 onClick = interaction::onApplyButtonClicked,
-                isEnabled = true,
+                isEnabled = state.hasFilterData,
                 isLoading = false,
                 isNegative = false,
                 modifier = Modifier.padding(12.dp),

--- a/viewModel/src/main/java/com/example/viewmodel/search/SearchUiState.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/SearchUiState.kt
@@ -26,6 +26,9 @@ data class FilterItemUiState(
     val selectedStarIndex: Int = 0,
     val genreItemUiStates: List<GenreItemUiState> = defaultGenreItemsUiState,
 ){
+    val hasFilterData: Boolean
+        get() = selectedStarIndex > 0 || genreItemUiStates.any { it.isSelected }
+
     companion object {
         val defaultGenreItemsUiState = GenreType.entries.toTypedArray().mapIndexed { index, genreType ->
             GenreItemUiState(


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request updates the behavior of the Apply button in the filter dialog.
Previously, the Apply button was always enabled regardless of user interaction.
Now, it remains disabled until the user selects at least one filter option — either a rating (star) or a genre.

---

## Changes Made

- Added hasFilterData property to FilterItemUiState to determine if any filter is selected.
- Updated Apply and Clear buttons to be enabled only when hasFilterData is true.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.