### PR TITLE
fix: tab Layout in search screen

### DIFF
--- a/designSystem/src/main/java/com/example/designsystem/components/TabLayout.kt
+++ b/designSystem/src/main/java/com/example/designsystem/components/TabLayout.kt
@@ -3,10 +3,9 @@ package com.example.designsystem.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
@@ -34,11 +33,9 @@ fun TabsLayout(
     selectedIndex: Int,
     onSelectTab: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    tabWidth: Dp = 172.dp,
     tabTopPadding: Dp = 8.dp,
     tabBottomPadding: Dp = 13.dp,
     tabsEndSpace: Dp = 16.dp,
-    innerPadding: Dp = 0.dp,
     selectedTextColor: Color = AppTheme.color.title,
     unselectedTextColor: Color = AppTheme.color.hint,
     containerColor: Color = AppTheme.color.surface,
@@ -46,11 +43,10 @@ fun TabsLayout(
     dividerColor: Color = AppTheme.color.stroke
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        ScrollableTabRow(
+        TabRow(
             modifier = modifier.fillMaxWidth(),
             containerColor = containerColor,
             selectedTabIndex = selectedIndex,
-            edgePadding = innerPadding,
             divider = {},
             indicator = { list ->
                 TabRowDefaults.SecondaryIndicator(
@@ -66,7 +62,7 @@ fun TabsLayout(
             tabs.fastForEachIndexed { index, text ->
                 Tab(
                     modifier = Modifier
-                        .width(tabWidth)
+                        .weight(1f)
                         .padding(end = if (index == tabs.lastIndex) 0.dp else tabsEndSpace),
                     selected = index == selectedIndex,
                     onClick = { onSelectTab(index) },

--- a/ui/src/main/java/com/example/ui/screens/search/SearchScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/search/SearchScreen.kt
@@ -1,6 +1,5 @@
 package com.example.ui.screens.search
 
-import android.R.attr.name
 import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
@@ -20,7 +19,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.designsystem.R
@@ -108,25 +106,22 @@ private fun SearchContent(
             isTrailingClickEnabled = state.query.isNotEmpty(),
             maxCharacters = 100
         )
+        AnimatedVisibility(!state.query.isEmpty()) {
+            TabsLayout(
+                modifier = Modifier.fillMaxWidth(),
+                tabs = listOf(stringResource(R.string.movies), stringResource(R.string.tv_shows)),
+                selectedIndex = state.selectedTabOption.index,
+                onSelectTab = { index -> interaction.onTabOptionClicked(TabOption.entries[index]) },
+            )
+        }
 
         AnimatedVisibility(!state.query.isEmpty()) {
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(160.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+                contentPadding = PaddingValues(vertical = 12.dp, horizontal = 16.dp)
             ) {
-                stickyHeader {
-                    TabsLayout(
-                        modifier = Modifier.fillMaxWidth(),
-                        tabs = listOf(
-                            stringResource(R.string.movies),
-                            stringResource(R.string.tv_shows)
-                        ),
-                        selectedIndex = state.selectedTabOption.index,
-                        onSelectTab = { index -> interaction.onTabOptionClicked(TabOption.entries[index]) },
-                    )
-                }
                 items(
                     if (state.selectedTabOption == TabOption.MOVIES) state.movies
                     else state.tvShows,


### PR DESCRIPTION
# Pull Request Template

## Description
This refactor ensures tabs in the Search screen span the full width and better match the intended UI design.
---

## Changes Made

- Replaced ScrollableTabRow with TabRow in TabsLayout to ensure tabs occupy full width.
- Removed unused tabWidth and innerPadding parameters from TabsLayout.
- Set each tab’s weight to 1f to distribute space equally.
- Updated SearchScreen layout by removing the sticky header for tabs — they are now static when the search query is not empty.

---

## Screenshots
before:
https://github.com/user-attachments/assets/eae3e84d-94f4-4140-a186-0e21a574fa73

after:
https://github.com/user-attachments/assets/1201cf88-b1e6-4a47-90c0-073fe54870d2
---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.