### PR TITLE
Reset Loading And Error States on Successful TV Show Result

### DIFF
--- a/domain/src/main/java/com/example/domain/exceptions/AflamiException.kt
+++ b/domain/src/main/java/com/example/domain/exceptions/AflamiException.kt
@@ -18,7 +18,7 @@ class InternetConnectionException: AflamiException()
 class NoSuggestedCountriesException: AflamiException()
 class NoMoviesForCountryException: AflamiException()
 
-class NoMoviesByKeywordFoundException: AflamiException()
+class NoSearchByKeywordResultFoundException: AflamiException()
 
 class CountryTooShortException: AflamiException()
 class CountryIsEmptyException: AflamiException()

--- a/domain/src/main/java/com/example/domain/useCase/GetMoviesByKeywordUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetMoviesByKeywordUseCase.kt
@@ -1,6 +1,6 @@
 package com.example.domain.useCase
 
-import com.example.domain.exceptions.NoMoviesByKeywordFoundException
+import com.example.domain.exceptions.NoSearchByKeywordResultFoundException
 import com.example.domain.repository.MovieRepository
 import com.example.entity.Movie
 
@@ -17,7 +17,7 @@ class GetMoviesByKeywordUseCase(
         return movieRepository.getMoviesByKeyword(keyword)
             .sortedByDescending { it.popularity }
             .ifEmpty {
-                throw NoMoviesByKeywordFoundException()
+                throw NoSearchByKeywordResultFoundException()
             }
     }
 }

--- a/domain/src/main/java/com/example/domain/useCase/GetTvShowByKeywordUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetTvShowByKeywordUseCase.kt
@@ -1,5 +1,6 @@
 package com.example.domain.useCase
 
+import com.example.domain.exceptions.NoSearchByKeywordResultFoundException
 import com.example.domain.repository.TvShowRepository
 import com.example.entity.TvShow
 
@@ -14,7 +15,8 @@ class GetTvShowByKeywordUseCase(
     ): List<TvShow> {
         return tvShowRepository.getTvShowByKeyword(keyword)
             .sortedByDescending { it.popularity }
-//            .filter { it.rating == rating }
-//            .filter { it.categories.any { category -> category.name == categoryName } }
+            .ifEmpty {
+                throw NoSearchByKeywordResultFoundException()
+            }
     }
 }

--- a/domain/src/test/java/com/example/domain/useCase/GetTvShowByKeywordUseCaseTest.kt
+++ b/domain/src/test/java/com/example/domain/useCase/GetTvShowByKeywordUseCaseTest.kt
@@ -56,6 +56,8 @@ class GetTvShowByKeywordUseCaseTest {
     @Test
     fun `should call getTvShowByKeyword from tvShowRepository`() =
         runBlocking {
+            coEvery { tvShowRepository.getTvShowByKeyword(any()) } returns fakeTvShowList
+
             getTvShowByKeywordUseCase("keyword")
             coVerify { tvShowRepository.getTvShowByKeyword("keyword") }
         }

--- a/viewModel/src/main/java/com/example/viewmodel/search/GlobalSearchViewModel.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/GlobalSearchViewModel.kt
@@ -110,7 +110,13 @@ class GlobalSearchViewModel(
     }
 
     private fun onFetchTvShowsSuccess(tvShows: List<TvShow>) {
-        updateState { it.copy(tvShows = tvShows.toTvShowUiStates()) }
+        updateState {
+            it.copy(
+                tvShows = tvShows.toTvShowUiStates(),
+                isLoading = false,
+                errorUiState = null
+            )
+        }
     }
 
     override fun onTextValuedChanged(text: String) {

--- a/viewModel/src/main/java/com/example/viewmodel/search/SearchUiState.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/SearchUiState.kt
@@ -3,7 +3,7 @@ package com.example.viewmodel.search
 import com.example.domain.exceptions.AflamiException
 import com.example.domain.exceptions.BlankQueryException
 import com.example.domain.exceptions.InvalidCharactersException
-import com.example.domain.exceptions.NoMoviesByKeywordFoundException
+import com.example.domain.exceptions.NoSearchByKeywordResultFoundException
 import com.example.domain.exceptions.QueryTooLongException
 import com.example.domain.exceptions.QueryTooShortException
 import com.example.viewmodel.common.GenreItemUiState
@@ -56,7 +56,7 @@ fun mapToSearchUiState(aflamiException: AflamiException): SearchErrorUiState {
         is QueryTooLongException -> SearchErrorUiState.QueryTooLong
         is InvalidCharactersException -> SearchErrorUiState.InvalidCharacters
         is BlankQueryException -> SearchErrorUiState.BlankQuery
-        is NoMoviesByKeywordFoundException -> SearchErrorUiState.NoMoviesByKeywordFoundException
+        is NoSearchByKeywordResultFoundException -> SearchErrorUiState.NoMoviesByKeywordFoundException
         else -> SearchErrorUiState.UnknownException
     }
 }


### PR DESCRIPTION
## Description
This PR updates the `onFetchTvShowsSuccess` function in `GlobalSearchViewModel` to reset the `isLoading` and `errorUiState` in the `SearchUiState` upon successful retrieval of TV shows.

Additionally, `NoMoviesByKeywordFoundException` in `SearchUiState.kt` has been renamed to `NoSearchByKeywordResultFoundException` to better reflect its purpose.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.