### PR TITLE
test: add RecentSearchRepositoryImpl tests

### DIFF
--- a/repository/src/test/java/com/example/repository/repository/RecentSearchRepositoryImplTest.kt
+++ b/repository/src/test/java/com/example/repository/repository/RecentSearchRepositoryImplTest.kt
@@ -1,0 +1,112 @@
+package com.example.repository.repository
+
+import com.example.repository.datasource.local.LocalRecentSearchDataSource
+import com.example.repository.dto.local.LocalSearchDto
+import com.example.repository.dto.local.utils.SearchType
+import com.example.repository.mapper.local.RecentSearchMapper
+import com.example.domain.repository.RecentSearchRepository
+import com.google.common.truth.Truth.assertThat
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecentSearchRepositoryImplTest {
+
+    private lateinit var repository: RecentSearchRepository
+
+    private val localRecentSearchDataSource: LocalRecentSearchDataSource = mockk()
+    private val recentSearchMapper: RecentSearchMapper = mockk()
+    private val now: Instant = Clock.System.now()
+
+    private val testKeyword = "Action"
+    private val testDto = LocalSearchDto(testKeyword, SearchType.BY_KEYWORD, now)
+
+    @BeforeEach
+    fun setup() {
+        repository = RecentSearchRepositoryImpl(localRecentSearchDataSource, recentSearchMapper)
+    }
+
+    @Test
+    fun `should upsert keyword search`() = runTest {
+        coEvery { localRecentSearchDataSource.upsertResentSearch(any()) } just Runs
+
+        repository.upsertRecentSearch(testKeyword)
+
+        coVerify {
+            localRecentSearchDataSource.upsertResentSearch(
+                withArg {
+                    assertThat(it.searchKeyword).isEqualTo(testKeyword)
+                    assertThat(it.searchType).isEqualTo(SearchType.BY_KEYWORD)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `should upsert actor search`() = runTest {
+        coEvery { localRecentSearchDataSource.upsertResentSearch(any()) } just Runs
+
+        repository.upsertRecentSearchForActor(testKeyword)
+
+        coVerify {
+            localRecentSearchDataSource.upsertResentSearch(
+                withArg {
+                    assertThat(it.searchKeyword).isEqualTo(testKeyword)
+                    assertThat(it.searchType).isEqualTo(SearchType.BY_ACTOR)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `should upsert country search`() = runTest {
+        coEvery { localRecentSearchDataSource.upsertResentSearch(any()) } just Runs
+
+        repository.upsertRecentSearchForCountry(testKeyword)
+
+        coVerify {
+            localRecentSearchDataSource.upsertResentSearch(
+                withArg {
+                    assertThat(it.searchKeyword).isEqualTo(testKeyword)
+                    assertThat(it.searchType).isEqualTo(SearchType.BY_COUNTRY)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `should get all recent searches`() = runTest {
+        val dtos = listOf(testDto)
+        val expected = listOf("Action")
+
+        coEvery { localRecentSearchDataSource.getRecentSearches() } returns dtos
+        every { recentSearchMapper.toDomainList(dtos) } returns expected
+
+        val result = repository.getAllRecentSearches()
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `should delete all recent searches`() = runTest {
+        coEvery { localRecentSearchDataSource.deleteAllSearches() } just Runs
+
+        repository.deleteAllRecentSearches()
+
+        coVerify { localRecentSearchDataSource.deleteAllSearches() }
+    }
+
+    @Test
+    fun `should delete specific recent search`() = runTest {
+        coEvery { localRecentSearchDataSource.deleteSearchByKeyword(testKeyword) } just Runs
+
+        repository.deleteRecentSearch(testKeyword)
+
+        coVerify { localRecentSearchDataSource.deleteSearchByKeyword(testKeyword) }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request adds unit tests for the RecentSearchRepositoryImpl to ensure it correctly handles upserting, retrieving, and deleting recent searches based on keyword, actor, or country. These tests improve test coverage and ensure the repository's behavior is as expected.

---

## Changes Made

- Added unit test class: RecentSearchRepositoryImplTest
- Mocked dependencies (LocalRecentSearchDataSource, RecentSearchMapper)
- upsertRecentSearch, upsertRecentSearchForActor, and upsertRecentSearchForCountry insert correct data with expiration
- getAllRecentSearches returns mapped results
- deleteRecentSearch deletes the correct item
- deleteAllRecentSearches clears the data source

---

## Screenshots 
<img width="995" height="138" alt="image" src="https://github.com/user-attachments/assets/b62c4e2a-a9b2-4949-8fb9-79fc3cd25178" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
