### PR TITLE
Fix/navigate back to global search

### DIFF
--- a/ui/src/main/java/com/example/ui/screens/search/SearchScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/search/SearchScreen.kt
@@ -53,6 +53,7 @@ import com.example.viewmodel.search.SearchUiEffect
 import com.example.viewmodel.search.SearchUiState
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
+import androidx.activity.compose.BackHandler
 
 @Composable
 fun SearchScreen(
@@ -95,6 +96,9 @@ private fun SearchContent(
     interaction: GlobalSearchInteractionListener,
     filterInteraction: FilterInteractionListener
 ) {
+    BackHandler(enabled = state.query.isNotEmpty()) {
+        interaction.onClearSearch()
+    }
 
     var bottomPadding by remember { mutableStateOf(0.dp) }
     Column(

--- a/viewModel/src/main/java/com/example/viewmodel/search/GlobalSearchViewModel.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/GlobalSearchViewModel.kt
@@ -134,7 +134,13 @@ class GlobalSearchViewModel(
 
     override fun onFilterButtonClicked() = updateState { it.copy(isDialogVisible = true) }
 
-    override fun onNavigateBackClicked() = sendNewEffect(SearchUiEffect.NavigateBack)
+    override fun onNavigateBackClicked() {
+        if (state.value.query.isNotEmpty()) {
+            onClearSearch()
+        } else {
+            sendNewEffect(SearchUiEffect.NavigateBack)
+        }
+    }
 
     override fun onWorldSearchCardClicked() = sendNewEffect(SearchUiEffect.NavigateToWorldSearch)
 
@@ -305,5 +311,19 @@ class GlobalSearchViewModel(
 
     override fun onClearButtonClicked() {
         updateState { it.copy(filterItemUiState = FilterItemUiState()) }
+    }
+
+    override fun onClearSearch() {
+        updateState { currentState ->
+            currentState.copy(
+                query = "",
+                movies = emptyList(),
+                tvShows = emptyList(),
+                selectedTabOption = TabOption.MOVIES,
+                errorUiState = null,
+                isDialogVisible = false,
+                filterItemUiState = FilterItemUiState()
+            )
+        }
     }
 }

--- a/viewModel/src/main/java/com/example/viewmodel/search/SearchIntractionListener.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/SearchIntractionListener.kt
@@ -17,6 +17,7 @@ interface GlobalSearchInteractionListener {
     fun onRecentSearchClicked(keyword: String)
     fun onClearRecentSearch(keyword: String)
     fun onClearAllRecentSearches()
+    fun onClearSearch()
 }
 
 


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request updates the behavior of the back navigation in the Global Search Screen.
When the user is viewing search results (i.e., after entering a query), pressing the back button (in the top app bar) will now reset the screen to its initial state — showing the Search By Actor and Search By Country cards — instead of navigating back to the previous screen.

---

## Changes Made

- Updated onNavigateBackClicked() in GlobalSearchViewModel
- If a query is present, the search is cleared and the screen resets to its default state.
- If the query is empty, it behaves as normal and navigates back.
- Added a BackHandler to handle the same behavior when the system back button is pressed.
- Ensured consistent back behavior between the top app bar and system navigation.

---

## Screenshots 

https://github.com/user-attachments/assets/03f43ff6-8433-4195-8016-ae3f135ad29c


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
