### PR TITLE
Fix/resolve search by country screen UI

### DIFF
--- a/designSystem/src/main/java/com/example/designsystem/components/CenterOfScreenContainer.kt
+++ b/designSystem/src/main/java/com/example/designsystem/components/CenterOfScreenContainer.kt
@@ -1,0 +1,82 @@
+package com.example.designsystem.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CenterOfScreenContainer(
+    unneededSpace: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    var paddingValueDp by remember { mutableStateOf(0.dp) }
+    var containerHeight by remember { mutableStateOf(0.dp) }
+    val screenHeight = getAppScreenHeight()
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(bottom = paddingValueDp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .onSizeChanged {
+                    paddingValueDp = getContainerSize(
+                        containerHeight,
+                        it,
+                        paddingValueDp,
+                        screenHeight,
+                        unneededSpace
+                    )
+                },
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun getAppScreenHeight(): Dp {
+    val fullScreenHeight =
+        LocalContext.current.resources.displayMetrics.heightPixels.dp
+    val statusBarHeight =
+        with(LocalDensity.current) { WindowInsets.safeDrawing.getTop(this).toDp() }
+    val navigationBarHeight =
+        with(LocalDensity.current) { WindowInsets.safeDrawing.getBottom(this).toDp() }
+
+    val screenHeight = remember { fullScreenHeight - statusBarHeight - navigationBarHeight }
+    return screenHeight
+}
+
+private fun getContainerSize(
+    containerHeight: Dp,
+    size: IntSize,
+    paddingValueDp: Dp,
+    screenHeight: Dp,
+    headerHeight: Dp
+): Dp {
+    var containerHeight1 = containerHeight
+    var paddingValueDp1 = paddingValueDp
+    containerHeight1 = size.height.dp
+    paddingValueDp1 =
+        if (screenHeight > headerHeight * 2 + containerHeight1)
+            headerHeight / 2
+        else 0.dp
+    return paddingValueDp1
+}

--- a/ui/src/main/java/com/example/ui/screens/searchByCountry/SearchByCountryScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/searchByCountry/SearchByCountryScreen.kt
@@ -33,12 +33,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.example.designsystem.R
 import com.example.designsystem.components.LoadingIndicator
@@ -137,20 +134,12 @@ fun SearchByCountryScreenContent(
     showCountriesDropdown: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    var textFieldSize by remember { mutableStateOf(IntSize.Zero) }
-    var appBarSectionHeight by remember { mutableStateOf(0.dp) }
-
     Column(
         modifier = modifier
             .fillMaxSize()
             .statusBarsPadding()
             .padding(horizontal = 16.dp)
     ) {
-        Column(
-            modifier = Modifier.onSizeChanged {
-                appBarSectionHeight = it.height.dp
-            }
-        ) {
             DefaultAppBar(
                 title = stringResource(R.string.world_tour_title),
                 showNavigateBackButton = true,
@@ -165,43 +154,25 @@ fun SearchByCountryScreenContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 8.dp)
-                    .onGloballyPositioned {
-                        textFieldSize = it.size
-                    }
             )
-        }
 
         Box {
             Box(
                 modifier = Modifier.fillMaxSize()
             ) {
+                val centerContentModifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(start = 8.dp, end = 8.dp)
                 when (screenContent) {
-                    ScreenContent.COUNTRY_TOUR -> ExploreCountries(
-                        Modifier
-                            .fillMaxSize()
-                            .align(Alignment.Center)
-                            .padding(start = 8.dp, end = 8.dp, bottom = appBarSectionHeight / 2)
-                    )
+                    ScreenContent.COUNTRY_TOUR -> ExploreCountries(centerContentModifier)
 
-                    ScreenContent.LOADING_MOVIES -> Loading(
-                        Modifier
-                            .align(Alignment.Center)
-                            .padding(start = 8.dp, end = 8.dp, bottom = appBarSectionHeight / 2)
-                    )
+                    ScreenContent.LOADING_MOVIES -> Loading(centerContentModifier)
 
                     ScreenContent.NO_INTERNET_CONNECTION -> NoInternetConnection(
-                        Modifier
-                            .align(
-                                Alignment.Center
-                            )
-                            .padding(start = 8.dp, end = 8.dp, bottom = appBarSectionHeight / 2)
+                        centerContentModifier
                     )
 
-                    ScreenContent.NO_MOVIES -> NoMoviesFound(
-                        Modifier
-                            .align(Alignment.Center)
-                            .padding(start = 8.dp, end = 8.dp, bottom = appBarSectionHeight / 2)
-                    )
+                    ScreenContent.NO_MOVIES -> NoMoviesFound(centerContentModifier)
 
                     ScreenContent.MOVIES -> SearchedMovies(
                         state,

--- a/ui/src/main/java/com/example/ui/screens/searchByCountry/SearchByCountryScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/searchByCountry/SearchByCountryScreen.kt
@@ -313,10 +313,10 @@ private fun SearchedMovies(
 ) {
     LazyVerticalGrid(
         modifier = modifier,
-        columns = GridCells.Fixed(2),
-        contentPadding = PaddingValues(top = 12.dp, bottom = 36.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        columns = GridCells.Adaptive(160.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(top = 12.dp, bottom = 36.dp),
     ) {
         items(
             items = state.movies,

--- a/ui/src/main/java/com/example/ui/screens/searchByCountry/SearchByCountryScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/searchByCountry/SearchByCountryScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,7 +65,7 @@ fun SearchByCountryScreen(
     val navController = LocalNavController.current
 
     val state by viewModel.state.collectAsState()
-    var screenContent by remember { mutableStateOf(ScreenContent.COUNTRY_TOUR) }
+    var screenContent by rememberSaveable { mutableStateOf(ScreenContent.COUNTRY_TOUR) }
     var showCountriesDropdown by remember { mutableStateOf(false) }
     var noSuggestedCountry by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
## Description

In this PR we fixed UI of `SearchByCountryScreen` for both orientations

---

## Changes Made

- Fixed screen content padding
- Fixed screen content not loaded after rotation in `SearchByCountryScreen`
- Made movies grid adaptive in `SearchByCountryScreen`
- Fixed position of screen states messages to be centered in `SearchByCountryScreen`

---

## Screenshots (if applicable)

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/a510e9a8-fc81-4c89-a602-a516c4f6bcbf" />

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/04047c96-6403-4af0-8ad3-7606472eaca9" />

<img width="2400" height="1080" alt="image" src="https://github.com/user-attachments/assets/c0b8ea88-0753-44df-a814-619258a0bea6" />

<img width="2400" height="1080" alt="image" src="https://github.com/user-attachments/assets/5c7697fa-2282-4fd8-9eb1-d2339f6ab5c9" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.