### PR TITLE
Add custom logger to the app and logs only in debug mode.

### DIFF
--- a/app/src/main/java/com/amsterdam/aflami/AppLogger.kt
+++ b/app/src/main/java/com/amsterdam/aflami/AppLogger.kt
@@ -18,19 +18,19 @@ class AppLogger : Logger {
             return getLoggerInfo()
         }
 
-    override fun d(message: Any, tag: String) {
+    override fun debug(message: Any, tag: String) {
         log(Log.DEBUG, "🐛", message.toString(), tag)
     }
 
-    override fun i(message: Any, tag: String) {
+    override fun info(message: Any, tag: String) {
         log(Log.INFO, "ℹ️", message.toString(), tag)
     }
 
-    override fun w(message: Any, tag: String) {
+    override fun warning(message: Any, tag: String) {
         log(Log.WARN, "⚠️", message.toString(), tag)
     }
 
-    override fun e(message: String, tag: String, throwable: Throwable?) {
+    override fun error(message: String, tag: String, throwable: Throwable?) {
         log(Log.ERROR, "🔥", message, tag, throwable)
     }
 

--- a/app/src/main/java/com/amsterdam/aflami/AppLogger.kt
+++ b/app/src/main/java/com/amsterdam/aflami/AppLogger.kt
@@ -1,0 +1,104 @@
+package com.amsterdam.aflami
+
+import android.util.Log
+import com.example.domain.logger.Logger
+import com.example.remotedatasource.BuildConfig
+
+class AppLogger : Logger {
+
+    companion object {
+        const val TAG_PREFIX = "AflamiApp"
+        const val MAX_LOG_LENGTH = 4000
+    }
+
+    private var isLoggerEnabled = BuildConfig.DEBUG
+
+    private val callerInfo: String
+        get() {
+            return getLoggerInfo()
+        }
+
+    override fun d(message: Any, tag: String) {
+        log(Log.DEBUG, "🐛", message.toString(), tag)
+    }
+
+    override fun i(message: Any, tag: String) {
+        log(Log.INFO, "ℹ️", message.toString(), tag)
+    }
+
+    override fun w(message: Any, tag: String) {
+        log(Log.WARN, "⚠️", message.toString(), tag)
+    }
+
+    override fun e(message: String, tag: String, throwable: Throwable?) {
+        log(Log.ERROR, "🔥", message, tag, throwable)
+    }
+
+    private fun getLoggerInfo(): String {
+        val stackTrace = Thread.currentThread().stackTrace
+        val loggerClassName = AppLogger::class.java.name
+        var foundLogger = false
+        for (element in stackTrace) {
+            if (element.className.startsWith(loggerClassName)) {
+                foundLogger = true
+                continue
+            }
+            if (foundLogger) {
+                val className = element.className.substringAfterLast('.')
+                return "($className.kt:${element.lineNumber}) - ${element.methodName}()"
+            }
+        }
+        return "(Unknown Source)"
+    }
+
+    private fun generateTag(customTag: String?): String {
+        val callerClassName = Thread.currentThread().stackTrace
+            .getOrNull(4)
+            ?.className
+            ?.substringAfterLast('.') ?: "App"
+
+        return if (customTag != null) {
+            "$TAG_PREFIX-$customTag"
+        } else {
+            "$TAG_PREFIX-$callerClassName"
+        }
+    }
+
+    private fun log(
+        priority: Int,
+        emoji: String,
+        message: String,
+        tag: String?,
+        throwable: Throwable? = null
+    ) {
+        if (!isLoggerEnabled) return
+
+        val finalTag = generateTag(tag)
+        val threadInfo = "[${Thread.currentThread().name}]"
+        val header = "$emoji $threadInfo $callerInfo"
+
+        if (throwable != null) {
+            Log.println(
+                priority,
+                finalTag,
+                "$header\n$message\n${Log.getStackTraceString(throwable)}"
+            )
+            return
+        }
+        if (message.length > MAX_LOG_LENGTH) {
+            logChunked(priority, finalTag, header, message)
+        } else {
+            Log.println(priority, finalTag, "$header\n$message")
+        }
+    }
+
+    private fun logChunked(priority: Int, tag: String, header: String, message: String) {
+        Log.println(priority, tag, "$header (part 1)")
+        var i = 0
+        while (i < message.length) {
+            val end = (i + MAX_LOG_LENGTH).coerceAtMost(message.length)
+            Log.println(priority, tag, message.substring(i, end))
+            i = end
+        }
+    }
+}

--- a/app/src/main/java/com/amsterdam/aflami/di/appLoggerModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/appLoggerModule.kt
@@ -1,0 +1,10 @@
+package com.amsterdam.aflami.di
+
+import com.amsterdam.aflami.AppLogger
+import com.example.domain.logger.Logger
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val appLoggerModule = module {
+    singleOf<Logger>(::AppLogger)
+}

--- a/app/src/main/java/com/amsterdam/aflami/di/appModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/appModule.kt
@@ -6,4 +6,5 @@ val appModule = listOf(
     repositoryModule,
     useCaseModule,
     viewModelModule,
+    appLoggerModule
 )

--- a/domain/src/main/java/com/example/domain/logger/Logger.kt
+++ b/domain/src/main/java/com/example/domain/logger/Logger.kt
@@ -1,0 +1,11 @@
+package com.example.domain.logger
+
+interface Logger {
+    fun d(message: Any, tag: String)
+
+    fun i(message: Any, tag: String)
+
+    fun w(message: Any, tag: String)
+
+    fun e(message: String, tag: String, throwable: Throwable? = null)
+}

--- a/domain/src/main/java/com/example/domain/logger/Logger.kt
+++ b/domain/src/main/java/com/example/domain/logger/Logger.kt
@@ -1,11 +1,11 @@
 package com.example.domain.logger
 
 interface Logger {
-    fun d(message: Any, tag: String)
+    fun debug(message: Any, tag: String)
 
-    fun i(message: Any, tag: String)
+    fun info(message: Any, tag: String)
 
-    fun w(message: Any, tag: String)
+    fun warning(message: Any, tag: String)
 
-    fun e(message: String, tag: String, throwable: Throwable? = null)
+    fun error(message: String, tag: String, throwable: Throwable? = null)
 }


### PR DESCRIPTION

## Description
Add custom logger to the app and logs only in debug mode.
If you need to use it, You need to include the domain module in your module. Also see the below images that makes anything clear.

---

## Changes Made

- Add the interface logger in domain module Logger.
- Provide AppLogger that implements the Logger in app module.
- Add its di in-app module to use it throw the other modules.
- Only Appear in debug mode.

---

## Screenshots (if applicable)

It is usage will be like that and Just You need to provide it in the class param
like -> private val logger: Logger

<img width="681" height="229" alt="logger_usage" src="https://github.com/user-attachments/assets/4d866891-efa0-4ef4-aceb-cfdaae919fa3" />


It will appear in logcat like this. And You can search for AflamiApp in the logcat to appear the logs only like shown in the image.

<img width="1531" height="469" alt="logger_result" src="https://github.com/user-attachments/assets/2ab3512c-bd63-48b1-987e-59a07435eae3" />

---

## Checklist

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

