### PR TITLE
Fix Infinte Retry Button Loading

### DIFF
--- a/ui/src/main/java/com/example/ui/screens/search/keywordSearch/SearchScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/search/keywordSearch/SearchScreen.kt
@@ -175,8 +175,8 @@ private fun SearchContent(
                 .fillMaxSize()
                 .padding(start = 8.dp, end = 8.dp)
         ) {
-            AnimatedVisibility(state.keyword.isNotBlank() && state.errorUiState != null) {
-                if (state.errorUiState is SearchErrorState.NoNetworkConnection) {
+            AnimatedVisibility(state.keyword.isNotBlank()) {
+                if (state.errorUiState != null && state.errorUiState is SearchErrorState.NoNetworkConnection) {
                     NoNetworkContainer(
                         onClickRetry = interaction::onClickRetryRequest,
                         modifier = Modifier.verticalScroll(rememberScrollState())
@@ -190,7 +190,7 @@ private fun SearchContent(
                         state.tvShows.isEmpty()
                     }
 
-                AnimatedVisibility(isSelectedTabSearchResultEmpty) {
+                AnimatedVisibility(state.errorUiState == null && isSelectedTabSearchResultEmpty) {
                     NoDataContainer(
                         imageRes = painterResource(com.example.ui.R.drawable.placeholder_no_result_found),
                         title = stringResource(R.string.no_search_result),

--- a/viewModel/src/main/java/com/example/viewmodel/search/keywordSearch/SearchViewModel.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/keywordSearch/SearchViewModel.kt
@@ -9,12 +9,12 @@ import com.example.entity.Movie
 import com.example.entity.TvShow
 import com.example.entity.category.MovieGenre
 import com.example.entity.category.TvShowGenre
-import com.example.viewmodel.shared.BaseViewModel
 import com.example.viewmodel.search.mapper.getSelectedGenreType
 import com.example.viewmodel.search.mapper.selectByMovieGenre
 import com.example.viewmodel.search.mapper.selectByTvGenre
 import com.example.viewmodel.search.mapper.toMoveUiStates
 import com.example.viewmodel.search.mapper.toTvShowUiStates
+import com.example.viewmodel.shared.BaseViewModel
 import com.example.viewmodel.utils.debounceSearch
 import com.example.viewmodel.utils.dispatcher.DispatcherProvider
 import kotlinx.coroutines.FlowPreview
@@ -182,11 +182,10 @@ class SearchViewModel(
 
     override fun onClickActorSearchCard() = sendNewEffect(SearchUiEffect.NavigateToActorSearch)
 
-    override fun onClickRetryRequest() {
-        updateState { it.copy(isLoading = true, errorUiState = null) }
-    }
+    override fun onClickRetryRequest() = onSearchKeywordChanged(_keyword.value)
 
-   // override fun onClickMovieCard() = sendNewEffect(SearchUiEffect.NavigateToMovieDetails)
+
+    // override fun onClickMovieCard() = sendNewEffect(SearchUiEffect.NavigateToMovieDetails)
 
     override fun onClickTabOption(tabOption: TabOption) {
         updateState {

--- a/viewModel/src/main/java/com/example/viewmodel/search/keywordSearch/SearchViewModel.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/search/keywordSearch/SearchViewModel.kt
@@ -184,9 +184,6 @@ class SearchViewModel(
 
     override fun onClickRetryRequest() = onSearchKeywordChanged(_keyword.value)
 
-
-    // override fun onClickMovieCard() = sendNewEffect(SearchUiEffect.NavigateToMovieDetails)
-
     override fun onClickTabOption(tabOption: TabOption) {
         updateState {
             it.copy(


### PR DESCRIPTION
## Description

This PR ensures that the search is retried when a network error occurs. It modifies the `SearchViewModel` to re-trigger the search upon a retry request. Additionally, the visibility of the "No Network" and "No Data" containers in `SearchScreen.kt` has been adjusted to correctly reflect the error state.

---


## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.