### PR TITLE
User Category Interest Tracking

### DIFF
--- a/app/src/main/java/com/amsterdam/aflami/di/localDataSourceModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/localDataSourceModule.kt
@@ -26,6 +26,8 @@ val localDataSourceModule = module {
     single { get<AflamiDatabase>().movieDao() }
     single { get<AflamiDatabase>().tvShowDao() }
     single { get<AflamiDatabase>().recentSearchDao() }
+    single { get<AflamiDatabase>().movieCategoryInterestDao() }
+    single { get<AflamiDatabase>().tvShowCategoryInterestDao()}
 
 // Local sources using singleOf with interface binding
     singleOf(::CategoryLocalDataSourceImpl) bind CategoryLocalSource::class

--- a/app/src/main/java/com/amsterdam/aflami/di/useCaceModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/useCaceModule.kt
@@ -7,6 +7,8 @@ import com.example.domain.useCase.GetMovieDetailsUseCase
 import com.example.domain.useCase.GetMoviesByActorUseCase
 import com.example.domain.useCase.GetMoviesByCountryUseCase
 import com.example.domain.useCase.GetSuggestedCountriesUseCase
+import com.example.domain.useCase.IncrementMovieGenreInterestUseCase
+import com.example.domain.useCase.IncrementTvShowGenreInterestUseCase
 import com.example.domain.useCase.RecentSearchesUseCase
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
@@ -20,4 +22,6 @@ val useCaseModule = module {
     singleOf(::GetSuggestedCountriesUseCase)
     singleOf(::RecentSearchesUseCase)
     singleOf(::GetAndFilterTvShowsByKeywordUseCase)
+    singleOf(::IncrementMovieGenreInterestUseCase)
+    singleOf(::IncrementTvShowGenreInterestUseCase)
 }

--- a/domain/src/main/java/com/example/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/MovieRepository.kt
@@ -5,6 +5,7 @@ import com.example.entity.Country
 import com.example.entity.Movie
 import com.example.entity.ProductionCompany
 import com.example.entity.Review
+import com.example.entity.category.MovieGenre
 
 interface MovieRepository {
     suspend fun getMoviesByKeyword(keyword: String): List<Movie>
@@ -19,4 +20,7 @@ interface MovieRepository {
     suspend fun getMovieGallery(movieId : Long) : List<String>
     suspend fun getMoviePosters(movieId : Long) : List<String>
     suspend fun getProductionCompany(movieId : Long) : List<ProductionCompany>
+
+    suspend fun incrementGenreInterest(genre: MovieGenre)
+    suspend fun getAllGenreInterests(): Map<MovieGenre, Int>
 }

--- a/domain/src/main/java/com/example/domain/repository/TvShowRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/TvShowRepository.kt
@@ -1,7 +1,11 @@
 package com.example.domain.repository
 
 import com.example.entity.TvShow
+import com.example.entity.category.TvShowGenre
 
 interface TvShowRepository {
     suspend fun getTvShowByKeyword(keyword: String): List<TvShow>
+
+    suspend fun incrementGenreInterest(genre: TvShowGenre)
+    suspend fun getAllGenreInterests(): Map<TvShowGenre, Int>
 }

--- a/domain/src/main/java/com/example/domain/useCase/GetAndFilterMoviesByKeywordUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetAndFilterMoviesByKeywordUseCase.kt
@@ -14,9 +14,14 @@ class GetAndFilterMoviesByKeywordUseCase(
         rating: Int = 0,
         movieGenre: MovieGenre = MovieGenre.ALL
     ): List<Movie> {
-       return movieRepository
-           .getMoviesByKeyword(keyword = keyword)
-           .filterMoviesWithRatingAndGenre(rating, genre = movieGenre)
+        val userInterest = movieRepository.getAllGenreInterests()
+
+        return movieRepository
+            .getMoviesByKeyword(keyword = keyword)
+            .filterMoviesWithRatingAndGenre(rating, genre = movieGenre)
+            .sortedByDescending { movie ->
+                movie.categories.maxOfOrNull { userInterest[it] ?: 0 }
+            }
     }
 
 

--- a/domain/src/main/java/com/example/domain/useCase/GetAndFilterTvShowsByKeywordUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetAndFilterTvShowsByKeywordUseCase.kt
@@ -14,8 +14,13 @@ class GetAndFilterTvShowsByKeywordUseCase(
         rating: Int = 0,
         tvGenre: TvShowGenre = TvShowGenre.ALL
     ): List<TvShow> {
+        val userInterest = tvShowRepository.getAllGenreInterests()
+
         return tvShowRepository.getTvShowByKeyword(keyword = keyword)
             .filterMoviesWithRatingAndGenre(rating, genre = tvGenre)
+            .sortedByDescending { movie ->
+                movie.categories.maxOfOrNull { userInterest[it] ?: 0 }
+            }
     }
 
 

--- a/domain/src/main/java/com/example/domain/useCase/GetMovieDetailsUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetMovieDetailsUseCase.kt
@@ -9,6 +9,7 @@ import com.example.entity.category.MovieGenre
 
 class GetMovieDetailsUseCase(
     private val movieRepository: MovieRepository,
+    private val incrementGenreInterest: IncrementMovieGenreInterestUseCase
 ) {
     suspend operator fun invoke(movieId: Long): MovieDetails {
         val movie = movieRepository.getMovieDetailsById(movieId)
@@ -18,6 +19,7 @@ class GetMovieDetailsUseCase(
         val movieGallery = movieRepository.getMovieGallery(movieId)
         val moviePosters = movieRepository.getMoviePosters(movieId).take(10)
         val productionsCompanies = movieRepository.getProductionCompany(movieId)
+
         return MovieDetails(
             movie = movie,
             reviews = reviews,
@@ -27,7 +29,7 @@ class GetMovieDetailsUseCase(
             movieGallery = movieGallery,
             moviePosters = moviePosters,
             productionsCompanies = productionsCompanies
-        )
+        ).also { incrementUserInterestByMovie(movie) }
     }
 
     data class MovieDetails(
@@ -37,7 +39,11 @@ class GetMovieDetailsUseCase(
         val actors: List<Actor>,
         val similarMovies: List<Movie>,
         val movieGallery: List<String>,
-        val moviePosters : List<String>,
-        val productionsCompanies : List<ProductionCompany>
+        val moviePosters: List<String>,
+        val productionsCompanies: List<ProductionCompany>
     )
+
+    private suspend fun incrementUserInterestByMovie(movie: Movie) {
+        return movie.categories.forEach { category -> incrementGenreInterest(category) }
+    }
 }

--- a/domain/src/main/java/com/example/domain/useCase/IncrementMovieGenreInterestUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/IncrementMovieGenreInterestUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.domain.useCase
+
+import com.example.domain.repository.MovieRepository
+import com.example.entity.category.MovieGenre
+
+class IncrementMovieGenreInterestUseCase(
+    private val movieRepository: MovieRepository
+) {
+    suspend operator fun invoke(genre: MovieGenre) {
+        movieRepository.incrementGenreInterest(genre)
+    }
+}

--- a/domain/src/main/java/com/example/domain/useCase/IncrementTvShowGenreInterestUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/IncrementTvShowGenreInterestUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.domain.useCase
+
+import com.example.domain.repository.TvShowRepository
+import com.example.entity.category.TvShowGenre
+
+class IncrementTvShowGenreInterestUseCase(
+    private val tvShowRepository: TvShowRepository
+) {
+    suspend operator fun invoke(genre: TvShowGenre) {
+        tvShowRepository.incrementGenreInterest(genre)
+    }
+}

--- a/domain/src/test/java/com/example/domain/useCase/IncrementMovieGenreInterestUseCaseTest.kt
+++ b/domain/src/test/java/com/example/domain/useCase/IncrementMovieGenreInterestUseCaseTest.kt
@@ -1,0 +1,34 @@
+import com.example.domain.repository.MovieRepository
+import com.example.domain.useCase.IncrementMovieGenreInterestUseCase
+import com.example.entity.category.MovieGenre
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.coEvery
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IncrementMovieGenreInterestUseCaseTest {
+
+    private lateinit var movieRepository: MovieRepository
+    private lateinit var useCase: IncrementMovieGenreInterestUseCase
+
+    @BeforeEach
+    fun setUp() {
+        movieRepository = mockk(relaxed = true)
+        useCase = IncrementMovieGenreInterestUseCase(movieRepository)
+    }
+
+    @Test
+    fun `should call repository to increment genre interest`() = runTest {
+        // Given
+        val genre = MovieGenre.ACTION
+        coEvery { movieRepository.incrementGenreInterest(genre) } returns Unit
+
+        // When
+        useCase(genre)
+
+        // Then
+        coVerify(exactly = 1) { movieRepository.incrementGenreInterest(genre) }
+    }
+}

--- a/domain/src/test/java/com/example/domain/useCase/IncrementTvShowGenreInterestUseCaseTest.kt
+++ b/domain/src/test/java/com/example/domain/useCase/IncrementTvShowGenreInterestUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.example.domain.useCase
+
+import com.example.domain.repository.TvShowRepository
+import com.example.entity.category.TvShowGenre
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IncrementTvShowGenreInterestUseCaseTest {
+
+    private lateinit var tvShowRepository: TvShowRepository
+    private lateinit var useCase: IncrementTvShowGenreInterestUseCase
+
+    @BeforeEach
+    fun setUp() {
+        tvShowRepository = mockk(relaxed = true)
+        useCase = IncrementTvShowGenreInterestUseCase(tvShowRepository)
+    }
+
+    @Test
+    fun `should call repository to increment TV show genre interest`() = runTest {
+        // Given
+        val genre = TvShowGenre.COMEDY
+        coEvery { tvShowRepository.incrementGenreInterest(genre) } returns Unit
+
+        // When
+        useCase(genre)
+
+        // Then
+        coVerify(exactly = 1) { tvShowRepository.incrementGenreInterest(genre) }
+    }
+}

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/AflamiDatabase.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/AflamiDatabase.kt
@@ -8,15 +8,19 @@ import androidx.room.TypeConverters
 import com.example.localdatasource.roomDataBase.converter.InstantConverter
 import com.example.localdatasource.roomDataBase.converter.SearchTypeConverter
 import com.example.localdatasource.roomDataBase.daos.CategoryDao
+import com.example.localdatasource.roomDataBase.daos.MovieCategoryInterestDao
 import com.example.localdatasource.roomDataBase.daos.CountryDao
 import com.example.localdatasource.roomDataBase.daos.MovieDao
 import com.example.localdatasource.roomDataBase.daos.RecentSearchDao
+import com.example.localdatasource.roomDataBase.daos.TvShowCategoryInterestDao
 import com.example.localdatasource.roomDataBase.daos.TvShowDao
+import com.example.repository.dto.local.LocalMovieCategoryInterestDto
 import com.example.repository.dto.local.LocalCountryDto
 import com.example.repository.dto.local.LocalMovieCategoryDto
 import com.example.repository.dto.local.LocalMovieDto
 import com.example.repository.dto.local.LocalSearchDto
 import com.example.repository.dto.local.LocalTvShowCategoryDto
+import com.example.repository.dto.local.LocalTvShowCategoryInterestDto
 import com.example.repository.dto.local.LocalTvShowDto
 import com.example.repository.dto.local.LocalTvShowWithSearchDto
 import com.example.repository.dto.local.MovieCategoryCrossRefDto
@@ -33,7 +37,9 @@ import com.example.repository.dto.local.TvShowCategoryCrossRefDto
         LocalTvShowWithSearchDto::class,
         MovieCategoryCrossRefDto::class,
         TvShowCategoryCrossRefDto::class,
-        SearchMovieCrossRefDto::class],
+        SearchMovieCrossRefDto::class,
+        LocalMovieCategoryInterestDto::class,
+        LocalTvShowCategoryInterestDto::class],
     version = 1,
     exportSchema = true
 )
@@ -44,6 +50,8 @@ abstract class AflamiDatabase : RoomDatabase() {
     abstract fun categoryDao(): CategoryDao
     abstract fun movieDao(): MovieDao
     abstract fun tvShowDao(): TvShowDao
+    abstract fun movieCategoryInterestDao(): MovieCategoryInterestDao
+    abstract fun tvShowCategoryInterestDao(): TvShowCategoryInterestDao
 
     companion object {
         private const val DATABASE_NAME = "AflamiDatabase"

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/MovieCategoryInterestDao.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/MovieCategoryInterestDao.kt
@@ -1,0 +1,29 @@
+package com.example.localdatasource.roomDataBase.daos
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.example.entity.category.MovieGenre
+import com.example.repository.dto.local.LocalMovieCategoryInterestDto
+import com.example.repository.dto.local.utils.DatabaseContract
+
+@Dao
+interface MovieCategoryInterestDao {
+
+    @Query("SELECT * FROM ${DatabaseContract.MOVIE_CATEGORY_INTEREST_TABLE}")
+    suspend fun getAllInterests(): List<LocalMovieCategoryInterestDto>
+
+    @Query("SELECT ${DatabaseContract.INTEREST_COUNT_FIELD} FROM ${DatabaseContract.MOVIE_CATEGORY_INTEREST_TABLE} WHERE ${DatabaseContract.GENRE_FIELD} = :genre")
+    suspend fun getInterestCount(genre: MovieGenre): Int?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertInterest(entity: LocalMovieCategoryInterestDto)
+
+    @Transaction
+    suspend fun incrementInterest(genre: MovieGenre) {
+        val current = getInterestCount(genre) ?: 0
+        insertInterest(LocalMovieCategoryInterestDto(genre, current + 1))
+    }
+}

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/MovieCategoryInterestDao.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/MovieCategoryInterestDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Upsert
 import com.example.entity.category.MovieGenre
 import com.example.repository.dto.local.LocalMovieCategoryInterestDto
 import com.example.repository.dto.local.utils.DatabaseContract
@@ -18,7 +19,7 @@ interface MovieCategoryInterestDao {
     @Query("SELECT ${DatabaseContract.INTEREST_COUNT_FIELD} FROM ${DatabaseContract.MOVIE_CATEGORY_INTEREST_TABLE} WHERE ${DatabaseContract.GENRE_FIELD} = :genre")
     suspend fun getInterestCount(genre: MovieGenre): Int?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertInterest(entity: LocalMovieCategoryInterestDto)
 
     @Transaction

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/TvShowCategoryInterestDao.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/TvShowCategoryInterestDao.kt
@@ -1,0 +1,29 @@
+package com.example.localdatasource.roomDataBase.daos
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import com.example.entity.category.TvShowGenre
+import com.example.repository.dto.local.LocalTvShowCategoryInterestDto
+import com.example.repository.dto.local.utils.DatabaseContract
+
+@Dao
+interface TvShowCategoryInterestDao {
+
+    @Query("SELECT * FROM ${DatabaseContract.TV_SHOW_CATEGORY_INTEREST_TABLE}")
+    suspend fun getAllInterests(): List<LocalTvShowCategoryInterestDto>
+
+    @Query("SELECT ${DatabaseContract.INTEREST_COUNT_FIELD} FROM ${DatabaseContract.TV_SHOW_CATEGORY_INTEREST_TABLE} WHERE ${DatabaseContract.GENRE_FIELD} = :genre")
+    suspend fun getInterestCount(genre: TvShowGenre): Int?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertInterest(entity: LocalTvShowCategoryInterestDto)
+
+    @Transaction
+    suspend fun incrementInterest(genre: TvShowGenre) {
+        val current = getInterestCount(genre) ?: 0
+        insertInterest(LocalTvShowCategoryInterestDto(genre, current + 1))
+    }
+}

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/TvShowCategoryInterestDao.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/daos/TvShowCategoryInterestDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Upsert
 import com.example.entity.category.TvShowGenre
 import com.example.repository.dto.local.LocalTvShowCategoryInterestDto
 import com.example.repository.dto.local.utils.DatabaseContract
@@ -18,7 +19,7 @@ interface TvShowCategoryInterestDao {
     @Query("SELECT ${DatabaseContract.INTEREST_COUNT_FIELD} FROM ${DatabaseContract.TV_SHOW_CATEGORY_INTEREST_TABLE} WHERE ${DatabaseContract.GENRE_FIELD} = :genre")
     suspend fun getInterestCount(genre: TvShowGenre): Int?
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun insertInterest(entity: LocalTvShowCategoryInterestDto)
 
     @Transaction

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/datasource/MovieLocalDataSourceImpl.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/datasource/MovieLocalDataSourceImpl.kt
@@ -1,5 +1,7 @@
 package com.example.localdatasource.roomDataBase.datasource
 
+import com.example.entity.category.MovieGenre
+import com.example.localdatasource.roomDataBase.daos.MovieCategoryInterestDao
 import com.example.localdatasource.roomDataBase.daos.MovieDao
 import com.example.repository.datasource.local.MovieLocalSource
 import com.example.repository.dto.local.LocalMovieDto
@@ -10,14 +12,15 @@ import kotlinx.datetime.Instant
 
 
 class MovieLocalDataSourceImpl(
-    private val dao: MovieDao
+    private val movieDao: MovieDao,
+    private val interestDao: MovieCategoryInterestDao
 ) : MovieLocalSource {
 
     override suspend fun getMoviesByKeywordAndSearchType(
         keyword: String,
         searchType: SearchType
     ): List<MovieWithCategories> {
-        return dao.getMoviesByKeywordAndSearchType(keyword, searchType)
+        return movieDao.getMoviesByKeywordAndSearchType(keyword, searchType)
     }
 
     override suspend fun addMoviesBySearchData(
@@ -26,7 +29,7 @@ class MovieLocalDataSourceImpl(
         searchType: SearchType,
         expireDate: Instant
     ) {
-        dao.insertMovies(movies)
+        movieDao.insertMovies(movies)
 
         val entries = movies.map { movie ->
             SearchMovieCrossRefDto(
@@ -36,18 +39,26 @@ class MovieLocalDataSourceImpl(
             )
         }
 
-        dao.insertSearchEntries(entries)
+        movieDao.insertSearchEntries(entries)
     }
 
     override suspend fun getSearchMovieCrossRefs(
         searchKeyword: String,
         searchType: SearchType
     ): List<SearchMovieCrossRefDto> {
-        return dao.getSearchMoviesCrossRef(searchKeyword, searchType)
+        return movieDao.getSearchMoviesCrossRef(searchKeyword, searchType)
     }
 
     override suspend fun getMovieById(movieId : Long): LocalMovieDto {
-        return dao.getMovieById(movieId)
+        return movieDao.getMovieById(movieId)
+    }
+
+    override suspend fun incrementGenreInterest(genre: MovieGenre) {
+        interestDao.incrementInterest(genre)
+    }
+
+    override suspend fun getAllGenreInterests(): Map<MovieGenre, Int> {
+        return interestDao.getAllInterests().associate { it.genre to it.interestCount }
     }
 
 }

--- a/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/datasource/TvShowLocalDataSourceImpl.kt
+++ b/localDatasource/src/main/java/com/example/localdatasource/roomDataBase/datasource/TvShowLocalDataSourceImpl.kt
@@ -1,5 +1,8 @@
 package com.example.localdatasource.roomDataBase.datasource
 
+import com.example.entity.category.TvShowGenre
+import com.example.localdatasource.roomDataBase.daos.MovieCategoryInterestDao
+import com.example.localdatasource.roomDataBase.daos.TvShowCategoryInterestDao
 import com.example.localdatasource.roomDataBase.daos.TvShowDao
 import com.example.repository.datasource.local.TvShowLocalSource
 import com.example.repository.dto.local.LocalTvShowDto
@@ -8,11 +11,12 @@ import com.example.repository.dto.local.relation.TvShowWithCategory
 import com.example.repository.dto.local.utils.SearchType
 
 class TvShowLocalDataSourceImpl(
-    private val dao: TvShowDao
+    private val tvShowDao: TvShowDao,
+    private val tvShowCategoryInterestDao: TvShowCategoryInterestDao
 ) : TvShowLocalSource {
 
     override suspend fun getTvShowsByKeywordAndSearchType(searchKeyword: String, searchType: SearchType): List<TvShowWithCategory> {
-        return dao.getTvShowsBySearchKeyword(searchKeyword, searchType = searchType)
+        return tvShowDao.getTvShowsBySearchKeyword(searchKeyword, searchType = searchType)
     }
 
     override suspend fun addTvShows(
@@ -20,7 +24,7 @@ class TvShowLocalDataSourceImpl(
         searchKeyword: String
     ) {
 
-        dao.addAllTvShows(tvShows)
+        tvShowDao.addAllTvShows(tvShows)
 
         val mappings = tvShows.map {
             LocalTvShowWithSearchDto(
@@ -29,6 +33,14 @@ class TvShowLocalDataSourceImpl(
             )
         }
 
-        dao.insertTvShowSearchMappings(mappings)
+        tvShowDao.insertTvShowSearchMappings(mappings)
+    }
+
+    override suspend fun incrementGenreInterest(genre: TvShowGenre) {
+        tvShowCategoryInterestDao.incrementInterest(genre)
+    }
+
+    override suspend fun getAllGenreInterests(): Map<TvShowGenre, Int> {
+        return tvShowCategoryInterestDao.getAllInterests().associate { it.genre to it.interestCount }
     }
 }

--- a/repository/src/main/java/com/example/repository/datasource/local/MovieLocalSource.kt
+++ b/repository/src/main/java/com/example/repository/datasource/local/MovieLocalSource.kt
@@ -1,5 +1,6 @@
 package com.example.repository.datasource.local
 
+import com.example.entity.category.MovieGenre
 import com.example.repository.dto.local.LocalMovieDto
 import com.example.repository.dto.local.SearchMovieCrossRefDto
 import com.example.repository.dto.local.relation.MovieWithCategories
@@ -25,4 +26,7 @@ interface MovieLocalSource {
     ): List<SearchMovieCrossRefDto>
 
     suspend fun getMovieById(movieId : Long) : LocalMovieDto
+
+    suspend fun incrementGenreInterest(genre: MovieGenre)
+    suspend fun getAllGenreInterests(): Map<MovieGenre, Int>
 }

--- a/repository/src/main/java/com/example/repository/datasource/local/TvShowLocalSource.kt
+++ b/repository/src/main/java/com/example/repository/datasource/local/TvShowLocalSource.kt
@@ -1,5 +1,7 @@
 package com.example.repository.datasource.local
 
+import com.example.entity.category.MovieGenre
+import com.example.entity.category.TvShowGenre
 import com.example.repository.dto.local.LocalTvShowDto
 import com.example.repository.dto.local.relation.TvShowWithCategory
 import com.example.repository.dto.local.utils.SearchType
@@ -7,4 +9,7 @@ import com.example.repository.dto.local.utils.SearchType
 interface TvShowLocalSource {
     suspend fun getTvShowsByKeywordAndSearchType(searchKeyword: String, searchType: SearchType): List<TvShowWithCategory>
     suspend fun addTvShows(tvShows: List<LocalTvShowDto>, searchKeyword: String)
+
+    suspend fun incrementGenreInterest(genre: TvShowGenre)
+    suspend fun getAllGenreInterests(): Map<TvShowGenre, Int>
 }

--- a/repository/src/main/java/com/example/repository/dto/local/LocalMovieCategoryInterestDto.kt
+++ b/repository/src/main/java/com/example/repository/dto/local/LocalMovieCategoryInterestDto.kt
@@ -1,0 +1,12 @@
+package com.example.repository.dto.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.entity.category.MovieGenre
+import com.example.repository.dto.local.utils.DatabaseContract
+
+@Entity(tableName = DatabaseContract.MOVIE_CATEGORY_INTEREST_TABLE)
+data class LocalMovieCategoryInterestDto(
+    @PrimaryKey val genre: MovieGenre,
+    val interestCount: Int
+)

--- a/repository/src/main/java/com/example/repository/dto/local/LocalTvShowCategoryInterestDto.kt
+++ b/repository/src/main/java/com/example/repository/dto/local/LocalTvShowCategoryInterestDto.kt
@@ -1,0 +1,12 @@
+package com.example.repository.dto.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.entity.category.TvShowGenre
+import com.example.repository.dto.local.utils.DatabaseContract
+
+@Entity(tableName = DatabaseContract.TV_SHOW_CATEGORY_INTEREST_TABLE)
+data class LocalTvShowCategoryInterestDto(
+    @PrimaryKey val genre: TvShowGenre,
+    val interestCount: Int
+)

--- a/repository/src/main/java/com/example/repository/dto/local/utils/DatabaseContract.kt
+++ b/repository/src/main/java/com/example/repository/dto/local/utils/DatabaseContract.kt
@@ -11,4 +11,10 @@ object DatabaseContract {
     const val MOVIE_CATEGORY_CROSS_REF_TABLE = "movie_category_cross_ref"
     const val SEARCH_MOVIE_CROSS_REF_TABLE = "search_movie_cross_ref"
     const val TV_SHOW_CATEGORY_CROSS_REF_TABLE = "tv_show_category_cross_ref"
+
+    const val MOVIE_CATEGORY_INTEREST_TABLE = "movie_category_interest"
+    const val TV_SHOW_CATEGORY_INTEREST_TABLE = "tv_show_category_interest"
+
+    const val INTEREST_COUNT_FIELD = "interestCount"
+    const val GENRE_FIELD = "genre"
 }

--- a/repository/src/main/java/com/example/repository/repository/MovieRepositoryImpl.kt
+++ b/repository/src/main/java/com/example/repository/repository/MovieRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.example.entity.Country
 import com.example.entity.Movie
 import com.example.entity.ProductionCompany
 import com.example.entity.Review
+import com.example.entity.category.MovieGenre
 import com.example.repository.datasource.local.MovieLocalSource
 import com.example.repository.datasource.remote.MovieRemoteSource
 import com.example.repository.dto.local.utils.SearchType
@@ -86,6 +87,14 @@ class MovieRepositoryImpl(
         return remoteProductionCompanyMapper.toEntityList(
             movieRemoteDataSource.getProductionCompany(movieId).productionCompanies
         )
+    }
+
+    override suspend fun incrementGenreInterest(genre: MovieGenre) {
+        movieLocalSource.incrementGenreInterest(genre)
+    }
+
+    override suspend fun getAllGenreInterests(): Map<MovieGenre, Int> {
+        return movieLocalSource.getAllGenreInterests()
     }
 
     private suspend fun getCachedMovies(keyword: String, searchType: SearchType): List<Movie>? {

--- a/repository/src/main/java/com/example/repository/repository/TvShowRepositoryImpl.kt
+++ b/repository/src/main/java/com/example/repository/repository/TvShowRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.example.repository.repository
 
 import com.example.domain.repository.TvShowRepository
 import com.example.entity.TvShow
+import com.example.entity.category.TvShowGenre
 import com.example.repository.datasource.local.TvShowLocalSource
 import com.example.repository.datasource.remote.TvShowsRemoteSource
 import com.example.repository.dto.local.utils.SearchType
@@ -27,6 +28,14 @@ class TvShowRepositoryImpl(
                     saveTvShowsToDatabase(remoteTvShows, keyword)
                     tvRemoteMapper.toEntityList(remoteTvShows.results)
                 }
+    }
+
+    override suspend fun incrementGenreInterest(genre: TvShowGenre) {
+        localTvDataSource.incrementGenreInterest(genre)
+    }
+
+    override suspend fun getAllGenreInterests(): Map<TvShowGenre, Int> {
+        return localTvDataSource.getAllGenreInterests()
     }
 
     private suspend fun getCachedTvShows(keyword: String): List<TvShow>? {


### PR DESCRIPTION
# Pull Request Template

## Description
When a user opens a movie, the app records interest in the movie's genres. This interest data is stored locally and used to prioritize search results based on the genres the user interacts with most.
---

### Local Data Storage

- Added `LocalMovieCategoryInterestDto` entity.
- Created `MOVIE_CATEGORY_INTEREST_TABLE` to store interest counts.
- Implemented `MovieCategoryInterestDao` with:
  - `getAllInterests()`
  - `getInterestCount(genre)`
  - `insertInterest(...)`
  - `incrementInterest(...)` (as a transaction).
- Updated `AflamiDatabase` to include the new DAO.

### Repository Layer

- Added:
  - `incrementGenreInterest(genre: MovieGenre)`
  - `getAllGenreInterests()`
  to both `MovieRepository` and `MovieLocalSource`.
- Implemented the methods in:
  - `MovieRepositoryImpl`
  - `MovieLocalDataSourceImpl`

### Domain Layer

- Added `IncrementMovieGenreInterestUseCase`.
- Modified `GetMovieDetailsUseCase` to increment genre interest when movie details are fetched.
- Modified `GetAndFilterMoviesByKeywordUseCase` to sort movies by interest count in matching genres.

### Dependency Injection

- Registered `MovieCategoryInterestDao` in `localDataSourceModule`.

---

## Tests

### Unit Tests

- `IncrementMovieGenreInterestUseCaseTest`  
  Verifies that `MovieRepository.incrementGenreInterest(...)` is invoked correctly.
  
- `IncrementTvShowGenreInterestUseCaseTest`  
  Verifies genre interest increment for TV show categories.
---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.