### PR TITLE
Fix crash if can't download ai model file

### DIFF
--- a/imageViewer/src/main/java/com/example/imageviewer/coil/ImageLoaderFactory.kt
+++ b/imageViewer/src/main/java/com/example/imageviewer/coil/ImageLoaderFactory.kt
@@ -1,6 +1,5 @@
 package com.example.imageviewer.coil
 
-
 import android.content.Context
 import coil.ImageLoader
 import com.example.imageviewer.classification.ImageClassifier
@@ -11,13 +10,13 @@ internal object ImageLoaderFactory {
 
     fun build(
         context: Context,
-        classifier: SFWImageClassifier,
+        classifier: SFWImageClassifier?,
         policy: SafetyPolicy
-    ): ImageLoader {
+    ): ImageLoader? {
+        if (classifier == null) return null
         val classifier: ImageClassifier = when (policy) {
             is SafetyPolicy.SFWPolicy -> classifier
         }
-
         return ImageLoader.Builder(context).components {
                 add(SafetyInterceptor(classifier))
             }.build()

--- a/imageViewer/src/main/java/com/example/imageviewer/coil/providers/ImageClassifierProvider.kt
+++ b/imageViewer/src/main/java/com/example/imageviewer/coil/providers/ImageClassifierProvider.kt
@@ -15,7 +15,7 @@ internal object ImageClassifierProvider {
     private var instance: SFWImageClassifier? = null
     private val mutex = Mutex()
 
-    suspend fun getInstance(): SFWImageClassifier {
+    suspend fun getInstance(): SFWImageClassifier? {
         return instance ?: mutex.withLock {
             instance ?: createInstance().also {
                 instance = it
@@ -23,7 +23,7 @@ internal object ImageClassifierProvider {
         }
     }
 
-    private suspend fun createInstance(): SFWImageClassifier {
+    private suspend fun createInstance(): SFWImageClassifier? {
         val modelFile = FirebaseModelManager.modelFile
         val options = Interpreter.Options().apply {
             setUseNNAPI(true)
@@ -35,9 +35,12 @@ internal object ImageClassifierProvider {
             val attempt = CoroutineScope(Dispatchers.IO).async {
                 FirebaseModelManager.getModelFileInstance()
             }
-            Interpreter(attempt.await(), options)
+            val modelFile = attempt.await()
+            if (modelFile != null) {
+                Interpreter(modelFile, options)
+            } else null
         }
-
+        if (interpreter == null) return null
         return SFWImageClassifier(interpreter)
     }
 }

--- a/imageViewer/src/main/java/com/example/imageviewer/coil/providers/ImageLoaderProvider.kt
+++ b/imageViewer/src/main/java/com/example/imageviewer/coil/providers/ImageLoaderProvider.kt
@@ -13,13 +13,13 @@ internal object ImageLoaderProvider {
     private var instance: ImageLoader? = null
     private val mutex = Mutex()
 
-    suspend fun getInstance(context: Context): ImageLoader {
+    suspend fun getInstance(context: Context): ImageLoader? {
         return instance ?: mutex.withLock {
             instance ?: createInstance(context.applicationContext)
         }
     }
 
-    private suspend fun createInstance(context: Context): ImageLoader {
+    private suspend fun createInstance(context: Context): ImageLoader? {
         val classifier = ImageClassifierProvider.getInstance()
         return ImageLoaderFactory.build(context, classifier, SafetyPolicy.SFWPolicy).also {
             instance = it

--- a/imageViewer/src/main/java/com/example/imageviewer/firebase/FirebaseModelManager.kt
+++ b/imageViewer/src/main/java/com/example/imageviewer/firebase/FirebaseModelManager.kt
@@ -3,36 +3,40 @@ package com.example.imageviewer.firebase
 import com.google.firebase.ml.modeldownloader.CustomModelDownloadConditions
 import com.google.firebase.ml.modeldownloader.DownloadType
 import com.google.firebase.ml.modeldownloader.FirebaseModelDownloader
+import kotlinx.coroutines.*
 import kotlinx.coroutines.tasks.await
 import java.io.File
-import java.io.IOException
 
 internal object FirebaseModelManager {
-
     private const val MODEL_NAME = "NSFW-Detector"
 
     @Volatile
     var modelFile: File? = null
         private set
 
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    suspend fun getModelFileInstance(): File {
-        return modelFile ?: downloadAndCacheModel().also { modelFile = it }
+    private val modelDownloadJob: Deferred<File?> by lazy {
+        scope.async {
+            downloadModel()
+        }
     }
 
-    private suspend fun downloadAndCacheModel(): File {
-        val conditions = CustomModelDownloadConditions.Builder()
-            .requireWifi()
-            .build()
+    suspend fun getModelFileInstance(): File? {
+        return modelDownloadJob.await()
+    }
 
-        return runCatching {
+    private suspend fun downloadModel(): File? {
+        if (modelFile != null) return modelFile
+        val conditions = CustomModelDownloadConditions.Builder().build()
+
+        return run {
             FirebaseModelDownloader.getInstance()
                 .getModel(MODEL_NAME, DownloadType.LOCAL_MODEL, conditions)
                 .await()
-        }.map { customModel ->
-            customModel.file ?: throw IOException("Downloaded model file is null.")
-        }.onSuccess { file ->
-            modelFile = file
-        }.getOrThrow()
+        }.let {
+            modelFile = it.file
+            modelFile
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixed crash if can't download ai file model of filtering images

---

## Changes Made

- Instead of crashing the app, I made app try to load model again if needed
- Removed `requireWifi()`, to be able to download the model in any connection, as 10MB isn't a heavy load on network quota

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.