### PR TITLE
Fix downloading ai model on mobile data

### DIFF
--- a/imageViewer/src/main/java/com/example/imageviewer/firebase/FirebaseModelManager.kt
+++ b/imageViewer/src/main/java/com/example/imageviewer/firebase/FirebaseModelManager.kt
@@ -21,9 +21,7 @@ internal object FirebaseModelManager {
     }
 
     private suspend fun downloadAndCacheModel(): File {
-        val conditions = CustomModelDownloadConditions.Builder()
-            .requireWifi()
-            .build()
+        val conditions = CustomModelDownloadConditions.Builder().build()
 
         return runCatching {
             FirebaseModelDownloader.getInstance()


### PR DESCRIPTION
## Description

Now the app can download ai model on mobile data not just wifi

---

## Changes Made

- Removed `requireWifi()` to be able to download the model in any connection, as 10MB isn't a heavy load on network quota

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.