### PR TITLE
Fix Release Mode issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.enableR8.fullMode=false


### PR DESCRIPTION
## Description
Fix the release mode network and resources doesn't load like the debug mode.

## Changes Made
List the changes introduced in this pull request:

- R8 full mode is disabled by setting `android.enableR8.fullMode=false` in `gradle.properties`. This can help resolve issues that may arise with R8 optimizations.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
This will be changed soon since we need to have a signing apk in release mode and enhance the optimization of the app.