### PR TITLE
Fix: Use HorizontalPager in MovieDetailsScreen

### DIFF
--- a/ui/src/main/java/com/example/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -157,7 +157,7 @@ fun MovieContent(
                             .fillMaxWidth()
                             .height(263.dp),
                 ) {
-                    VerticalPager(
+                    HorizontalPager(
                         state = pagerState,
                         modifier = Modifier.fillMaxSize()
                     ) { page ->


### PR DESCRIPTION

# Pull Request Template

## Description
The `MovieDetailsScreen` was incorrectly using `VerticalPager` for displaying movie images. This commit changes it to `HorizontalPager` to allow horizontal scrolling of images.

---

## Changes Made
List the changes introduced in this pull request:


---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.