### PR TITLE
Add Proguard rules for Room DB and Kotlinx Serialization

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,4 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keepdirectories com.amsterdam.aflami.*
+
+# Kotlinx Serializatione.
+-keep @kotlinx.serialization.Serializable class *
+-keepnames class * { @kotlinx.serialization.SerialName *; }
+
+# Room DB
+-keep class * extends androidx.room.RoomDatabase { *; }

--- a/designSystem/proguard-rules.pro
+++ b/designSystem/proguard-rules.pro
@@ -19,4 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keepdirectories com.example.designsystem.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.enableR8.fullMode=false

--- a/repository/proguard-rules.pro
+++ b/repository/proguard-rules.pro
@@ -19,5 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
-
--keepdirectories com.example.repository.dto.*


### PR DESCRIPTION
## Description
This Pr introduces Proguard rules to ensure proper functioning of Room DB and Kotlinx Serialization in release builds.

---

## Changes Made
List the changes introduced in this pull request:

- Added rules to keep classes annotated with `@kotlinx.serialization.Serializable` and their `@kotlinx.serialization.SerialName` fields.
- Added a rule to keep classes extending `androidx.room.RoomDatabase`.
- Removed `-keepdirectories` rules from app, repository, and designSystem modules as they are now handled by the more specific rules or are not necessary.
- Removed `android.enableR8.fullMode=false` from `gradle.properties` to potentially enable more aggressive R8 optimizations.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.