### PR TITLE
Add TV shows mixed with Movies in Home and Top-rated Screens

### DIFF
--- a/app/src/main/java/com/amsterdam/aflami/di/useCaseModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/useCaseModule.kt
@@ -2,18 +2,21 @@ package com.amsterdam.aflami.di
 
 import com.example.domain.useCase.GetAndFilterMoviesByKeywordUseCase
 import com.example.domain.useCase.GetAndFilterTvShowsByKeywordUseCase
+import com.example.domain.useCase.GetEpisodesBySeasonNumberUseCase
 import com.example.domain.useCase.GetHomeScreenDataUseCase
 import com.example.domain.useCase.GetMovieCastUseCase
 import com.example.domain.useCase.GetMovieDetailsUseCase
 import com.example.domain.useCase.GetMoviesByActorUseCase
 import com.example.domain.useCase.GetMoviesByCountryUseCase
 import com.example.domain.useCase.GetPopularMoviesUseCase
+import com.example.domain.useCase.GetPopularTvShowsUseCase
 import com.example.domain.useCase.GetSuggestedCountriesUseCase
-import com.example.domain.useCase.GetUpcomingMoviesUseCase
 import com.example.domain.useCase.GetTopRatedMoviesUseCase
-import com.example.domain.useCase.RecentSearchesUseCase
+import com.example.domain.useCase.GetTopRatedScreenDataUseCase
+import com.example.domain.useCase.GetTopRatedTvShowsUseCase
 import com.example.domain.useCase.GetTvShowDetailsUseCase
-import com.example.domain.useCase.GetEpisodesBySeasonNumberUseCase
+import com.example.domain.useCase.GetUpcomingMoviesUseCase
+import com.example.domain.useCase.RecentSearchesUseCase
 import com.example.domain.useCase.authentication.GetsSessionType
 import com.example.domain.useCase.authentication.LoginAsGuestUseCase
 import com.example.domain.useCase.authentication.LoginWithPasswordUseCase
@@ -33,9 +36,12 @@ val useCaseModule = module {
     singleOf(::RecentSearchesUseCase)
     singleOf(::GetAndFilterTvShowsByKeywordUseCase)
     singleOf(::GetPopularMoviesUseCase)
+    singleOf(::GetPopularTvShowsUseCase)
     singleOf(::GetEpisodesBySeasonNumberUseCase)
     singleOf(::GetTvShowDetailsUseCase)
     singleOf(::GetUpcomingMoviesUseCase)
     singleOf(::GetTopRatedMoviesUseCase)
+    singleOf(::GetTopRatedTvShowsUseCase)
     singleOf(::GetHomeScreenDataUseCase)
+    singleOf(::GetTopRatedScreenDataUseCase)
 }

--- a/domain/src/main/java/com/example/domain/repository/TvShowRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/TvShowRepository.kt
@@ -6,9 +6,12 @@ import com.example.entity.ProductionCompany
 import com.example.entity.Review
 import com.example.entity.Season
 import com.example.entity.TvShow
-import com.example.entity.category.TvShowGenre
 
 interface TvShowRepository {
+
+    suspend fun getPopularTvShows(): List<TvShow>
+    suspend fun getTopRatedTvShows(): List<TvShow>
+
     suspend fun getTvShowByKeyword(keyword: String, page: Int, tvShowsPerPage: Int): List<TvShow>
     suspend fun getTvShowDetails(tvShowId: Long): TvShow
     suspend fun getTvShowCast(tvShowId: Long): List<Actor>

--- a/domain/src/main/java/com/example/domain/useCase/GetHomeScreenDataUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetHomeScreenDataUseCase.kt
@@ -1,24 +1,32 @@
 package com.example.domain.useCase
 
 import com.example.entity.Movie
+import com.example.entity.TvShow
 import com.example.entity.category.MovieGenre
 
 class GetHomeScreenDataUseCase(
-    private val getTopRatedMoviesUseCase : GetTopRatedMoviesUseCase,
+    private val getTopRatedMoviesUseCase: GetTopRatedMoviesUseCase,
+    private val getTopRatedTvShowsUseCase: GetTopRatedTvShowsUseCase,
     private val getPopularMoviesUseCase: GetPopularMoviesUseCase,
+    private val getPopularTvShowsUseCase: GetPopularTvShowsUseCase,
     private val getUpcomingMoviesUseCase: GetUpcomingMoviesUseCase,
-    ) {
+) {
 
     suspend operator fun invoke(): HomeScreenData {
         return HomeScreenData(
             topRatedMovies = getTopRatedMoviesUseCase(),
+            topRatedTvShows = getTopRatedTvShowsUseCase(),
             popularMovies = getPopularMoviesUseCase(),
+            popularTvShows = getPopularTvShowsUseCase(),
             upComingMovies = getUpcomingMoviesUseCase(MovieGenre.ALL)
         )
     }
+
     data class HomeScreenData(
         val topRatedMovies: List<Movie>,
+        val topRatedTvShows: List<TvShow>,
         val popularMovies: List<Movie>,
-        val upComingMovies : List<Movie>
+        val popularTvShows: List<TvShow>,
+        val upComingMovies: List<Movie>
     )
 }

--- a/domain/src/main/java/com/example/domain/useCase/GetPopularTvShowsUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetPopularTvShowsUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.domain.useCase
+
+import com.example.domain.repository.TvShowRepository
+import com.example.entity.TvShow
+
+class GetPopularTvShowsUseCase (private val tvShowRepository: TvShowRepository) {
+    suspend operator fun invoke(): List<TvShow> {
+        return tvShowRepository.getPopularTvShows()
+    }
+}

--- a/domain/src/main/java/com/example/domain/useCase/GetTopRatedScreenDataUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetTopRatedScreenDataUseCase.kt
@@ -1,0 +1,22 @@
+package com.example.domain.useCase
+
+import com.example.entity.Movie
+import com.example.entity.TvShow
+
+class GetTopRatedScreenDataUseCase(
+    private val getTopRatedMoviesUseCase: GetTopRatedMoviesUseCase,
+    private val getTopRatedTvShowsUseCase: GetTopRatedTvShowsUseCase,
+) {
+
+    suspend operator fun invoke(): TopRatedScreenData {
+        return TopRatedScreenData(
+            topRatedMovies = getTopRatedMoviesUseCase(),
+            topRatedTvShows = getTopRatedTvShowsUseCase(),
+        )
+    }
+
+    data class TopRatedScreenData(
+        val topRatedMovies: List<Movie>,
+        val topRatedTvShows: List<TvShow>
+    )
+}

--- a/domain/src/main/java/com/example/domain/useCase/GetTopRatedTvShowsUseCase.kt
+++ b/domain/src/main/java/com/example/domain/useCase/GetTopRatedTvShowsUseCase.kt
@@ -1,0 +1,10 @@
+package com.example.domain.useCase
+
+import com.example.domain.repository.TvShowRepository
+import com.example.entity.TvShow
+
+class GetTopRatedTvShowsUseCase (private val tvShowRepository: TvShowRepository) {
+    suspend operator fun invoke(): List<TvShow> {
+        return tvShowRepository.getTopRatedTvShows()
+    }
+}

--- a/remoteDatasource/src/main/java/com/example/remotedatasource/api/TvShowsApiService.kt
+++ b/remoteDatasource/src/main/java/com/example/remotedatasource/api/TvShowsApiService.kt
@@ -13,6 +13,12 @@ import retrofit2.http.Query
 
 interface TvShowsApiService {
 
+    @GET(TV_POPULAR)
+    suspend fun getPopularTvShows(): RemoteTvShowResponse
+
+    @GET(TOP_RATED_TV_SHOWS)
+    suspend fun getTopRatedTvShows(): RemoteTvShowResponse
+
     @GET(SEARCH_TV_URL)
     suspend fun getTvShowsByKeyword(
         @Query(QUERY_KEY) keyword: String,
@@ -56,6 +62,11 @@ interface TvShowsApiService {
     ): EpisodeResponse
 
     companion object {
+
+        private const val TV_POPULAR = "tv/popular"
+
+        private const val TOP_RATED_TV_SHOWS = "tv/top_rated"
+
         private const val SEARCH_TV_URL = "search/tv"
         private const val QUERY_KEY = "query"
         private const val PAGE_KEY = "page"

--- a/remoteDatasource/src/main/java/com/example/remotedatasource/datasource/TvRemoteDataSourceImpl.kt
+++ b/remoteDatasource/src/main/java/com/example/remotedatasource/datasource/TvRemoteDataSourceImpl.kt
@@ -13,6 +13,13 @@ import com.example.repository.dto.remote.review.ReviewsResponse
 class TvRemoteDataSourceImpl(
     private val tvShowsServiceProvider: TvShowsServiceProvider
 ) : TvShowsRemoteSource {
+    override suspend fun getPopularTvShows(): RemoteTvShowResponse {
+        return tvShowsServiceProvider.getPopularTvShows()
+    }
+
+    override suspend fun getTopRatedTvShows(): RemoteTvShowResponse {
+        return tvShowsServiceProvider.getTopRatedTvShows()
+    }
 
     override suspend fun getTvShowsByKeyword(keyword: String, page: Int): RemoteTvShowResponse {
         return tvShowsServiceProvider.getTvShowsByKeyword(keyword, page)

--- a/remoteDatasource/src/main/java/com/example/remotedatasource/serviceProvider/TvShowsServiceProvider.kt
+++ b/remoteDatasource/src/main/java/com/example/remotedatasource/serviceProvider/TvShowsServiceProvider.kt
@@ -9,6 +9,8 @@ import com.example.repository.dto.remote.movieGallery.RemoteGalleryResponse
 import com.example.repository.dto.remote.review.ReviewsResponse
 
 interface TvShowsServiceProvider {
+    suspend fun getPopularTvShows(): RemoteTvShowResponse
+    suspend fun getTopRatedTvShows(): RemoteTvShowResponse
     suspend fun getTvShowsByKeyword(keyword: String, page: Int): RemoteTvShowResponse
     suspend fun getTvShowDetailsById(tvShowId: Long): TvShowDetailsRemoteResponse
     suspend fun getTvShowCast(tvShowId: Long): RemoteCastAndCrewResponse

--- a/remoteDatasource/src/main/java/com/example/remotedatasource/serviceProvider/implementation/TvShowsServiceProviderImpl.kt
+++ b/remoteDatasource/src/main/java/com/example/remotedatasource/serviceProvider/implementation/TvShowsServiceProviderImpl.kt
@@ -14,6 +14,13 @@ import com.example.repository.dto.remote.review.ReviewsResponse
 class TvShowsServiceProviderImpl(
     private val tvShowsApiService: TvShowsApiService
 ) : TvShowsServiceProvider {
+    override suspend fun getPopularTvShows(): RemoteTvShowResponse {
+        return responseCall { tvShowsApiService.getPopularTvShows() }
+    }
+
+    override suspend fun getTopRatedTvShows(): RemoteTvShowResponse {
+        return responseCall { tvShowsApiService.getTopRatedTvShows() }
+    }
 
     override suspend fun getTvShowsByKeyword(keyword: String, page: Int): RemoteTvShowResponse {
         return responseCall {

--- a/repository/src/main/java/com/example/repository/datasource/remote/TvShowsRemoteSource.kt
+++ b/repository/src/main/java/com/example/repository/datasource/remote/TvShowsRemoteSource.kt
@@ -9,6 +9,10 @@ import com.example.repository.dto.remote.movieGallery.RemoteGalleryResponse
 import com.example.repository.dto.remote.review.ReviewsResponse
 
 interface TvShowsRemoteSource {
+
+    suspend fun getPopularTvShows(): RemoteTvShowResponse
+    suspend fun getTopRatedTvShows(): RemoteTvShowResponse
+
     suspend fun getTvShowsByKeyword(
         keyword: String,
         page: Int,

--- a/repository/src/main/java/com/example/repository/repository/TvShowRepositoryImpl.kt
+++ b/repository/src/main/java/com/example/repository/repository/TvShowRepositoryImpl.kt
@@ -126,6 +126,14 @@ class TvShowRepositoryImpl(
         )
     }
 
+    override suspend fun getPopularTvShows(): List<TvShow> {
+        return tvRemoteMapper.toEntityList(remoteTvDataSource.getPopularTvShows().results)
+    }
+
+    override suspend fun getTopRatedTvShows(): List<TvShow> {
+        return tvRemoteMapper.toEntityList(remoteTvDataSource.getTopRatedTvShows().results)
+    }
+
     private suspend fun getTvShowFromLocal(
         keyword: String,
         page: Int,

--- a/ui/src/main/java/com/example/ui/screens/home/HomeScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/home/HomeScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -27,7 +27,6 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.designsystem.components.LoadingContainer
 import com.example.designsystem.theme.AflamiTheme
@@ -41,8 +40,8 @@ import com.example.ui.navigation.Route
 import com.example.ui.navigation.Route.MovieDetails
 import com.example.ui.screens.home.sections.AnimatedSectionVisibility
 import com.example.ui.screens.home.sections.BlurredMoviePoster
-import com.example.ui.screens.home.sections.topRatingSection
 import com.example.ui.screens.home.sections.popularSection
+import com.example.ui.screens.home.sections.topRatingSection
 import com.example.ui.screens.home.sections.upcomingMoviesSection
 import com.example.ui.utils.safeNavigate
 import com.example.viewmodel.home.HomeEffect
@@ -103,7 +102,7 @@ private fun HomeScreenContent(
         animationSpec = tween(800),
         label = "AppBarScrollColor"
     )
-    var blurOffsetY by remember { mutableStateOf(-12f) }
+    var blurOffsetY by remember { mutableFloatStateOf(-12f) }
 
     val nestedScrollConnection = remember {
         object : NestedScrollConnection {
@@ -115,12 +114,14 @@ private fun HomeScreenContent(
         }
     }
 
-    Box(modifier = Modifier
-        .fillMaxSize()
-        .nestedScroll(nestedScrollConnection)) {
-        AnimatedSectionVisibility(visible = state.popularMovies.isNotEmpty()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(nestedScrollConnection)
+    ) {
+        AnimatedSectionVisibility(visible = state.popularMediaItems.isNotEmpty()) {
             BlurredMoviePoster(
-                posterUrl = state.popularMovies[pagerState.currentPage % state.popularMovies.size].posterUrl,
+                posterUrl = state.popularMediaItems[pagerState.currentPage % state.popularMediaItems.size].posterUrl,
                 modifier = Modifier.offset { IntOffset(x = 0, y = blurOffsetY.roundToInt()) }
             )
         }
@@ -140,7 +141,7 @@ private fun HomeScreenContent(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
                 onSearchClicked = interactionListener::onClickSearch,
             )
-            AnimatedSectionVisibility(visible = state.popularMovies.isNotEmpty()) {
+            AnimatedSectionVisibility(visible = state.popularMediaItems.isNotEmpty()) {
                 LazyColumn(
                     modifier = modifier
                         .fillMaxSize(),
@@ -148,11 +149,11 @@ private fun HomeScreenContent(
                 ) {
 
                     popularSection(
-                        popularMovies = state.popularMovies,
+                        popularMovies = state.popularMediaItems,
                         pagerState = pagerState
                     )
                     topRatingSection(
-                        topRatedMovies = state.topRatedMovies,
+                        topRatedMediaItems = state.topRatedMediaItems,
                         onClickMovie = interactionListener::onClickMovie,
                         onClickShowAll = interactionListener::onClickShowAllToRatedMovies
                     )

--- a/ui/src/main/java/com/example/ui/screens/home/component/PopularMediaItemCard.kt
+++ b/ui/src/main/java/com/example/ui/screens/home/component/PopularMediaItemCard.kt
@@ -1,47 +1,47 @@
 package com.example.ui.screens.home.component
 
-import androidx.compose.runtime.Composable
-import androidx.compose.foundation.layout.Column
-import com.example.designsystem.components.Icon
-import com.example.designsystem.components.ImageErrorIndicator
-import com.example.designsystem.components.ImageLoadingIndicator
-import com.example.designsystem.components.RatingChip
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import com.example.imageviewer.ui.SafeImageView
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.unit.dp
-import com.example.designsystem.theme.AppTheme
-import com.example.designsystem.components.Text
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.example.designsystem.R
+import com.example.designsystem.components.Icon
+import com.example.designsystem.components.ImageErrorIndicator
+import com.example.designsystem.components.ImageLoadingIndicator
+import com.example.designsystem.components.RatingChip
+import com.example.designsystem.components.Text
 import com.example.designsystem.theme.AflamiTheme
+import com.example.designsystem.theme.AppTheme
 import com.example.designsystem.utils.ThemeAndLocalePreviews
-import com.example.viewmodel.home.HomeUiState.PopularMovieItemUiState
+import com.example.imageviewer.ui.SafeImageView
+import com.example.viewmodel.home.HomeUiState.PopularMediaItemUiState
 
 @Composable
-fun PopularMovieCard(
-    popularMovie: PopularMovieItemUiState,
+fun PopularMediaItemCard(
+    popularMovie: PopularMediaItemUiState,
     ratingAlpha: Float,
-    imageWidth : Dp,
-    imageHeight : Dp ,
+    imageWidth: Dp,
+    imageHeight: Dp,
     modifier: Modifier = Modifier
 ) {
 
-    Column(modifier = modifier,horizontalAlignment = Alignment.CenterHorizontally) {
-        Box() {
-            Box (
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Box {
+            Box(
                 Modifier.height(300.dp),
                 contentAlignment = Alignment
                     .BottomCenter
@@ -51,7 +51,8 @@ fun PopularMovieCard(
                     contentDescription = "",
                     modifier =
                         Modifier
-                            .size(imageWidth,imageHeight).clip(RoundedCornerShape(24.dp)),
+                            .size(imageWidth, imageHeight)
+                            .clip(RoundedCornerShape(24.dp)),
                     onLoading = { ImageLoadingIndicator() },
                     onError = { ImageErrorIndicator() },
                 )
@@ -88,14 +89,14 @@ fun PopularMovieCard(
 @ThemeAndLocalePreviews
 @Composable
 private fun PopularMovieCardPreview() {
-    val dummyMovie = PopularMovieItemUiState(
+    val dummyMovie = PopularMediaItemUiState(
         name = "Inception",
         posterUrl = "https://image.tmdb.org/t/p/w500/qmDpIHrmpJINaRKAfWQfftjCdyi.jpg",
         rating = "8.8"
     )
 
     AflamiTheme {
-        PopularMovieCard(
+        PopularMediaItemCard(
             popularMovie = dummyMovie,
             modifier = Modifier
                 .width(244.dp)

--- a/ui/src/main/java/com/example/ui/screens/home/sections/PopularSection.kt
+++ b/ui/src/main/java/com/example/ui/screens/home/sections/PopularSection.kt
@@ -25,13 +25,13 @@ import com.example.designsystem.components.SectionTitle
 import com.example.designsystem.theme.AflamiTheme
 import com.example.designsystem.theme.AppTheme
 import com.example.designsystem.utils.ThemeAndLocalePreviews
-import com.example.ui.screens.home.component.PopularMovieCard
-import com.example.viewmodel.home.HomeUiState.PopularMovieItemUiState
+import com.example.ui.screens.home.component.PopularMediaItemCard
+import com.example.viewmodel.home.HomeUiState.PopularMediaItemUiState
 import kotlinx.coroutines.delay
 import kotlin.math.absoluteValue
 
 @SuppressLint("RestrictedApi", "ConfigurationScreenWidthHeight", "UnusedBoxWithConstraintsScope")
-fun LazyListScope.popularSection(popularMovies: List<PopularMovieItemUiState>, pagerState: PagerState) {
+fun LazyListScope.popularSection(popularMovies: List<PopularMediaItemUiState>, pagerState: PagerState) {
     item {
             SectionTitle(
                 title = stringResource(R.string.popular),
@@ -72,7 +72,7 @@ fun LazyListScope.popularSection(popularMovies: List<PopularMovieItemUiState>, p
                         targetValue = androidx.compose.ui.util.lerp(0f, 1f, 1f - currentPageOffset.coerceIn(0f, 1f)),
                         label = "height"
                     )
-                    PopularMovieCard(
+                    PopularMediaItemCard(
                         popularMovie = popularMovies[page % popularMovies.size],
                         ratingAlpha = rateAlpha,
                         imageWidth = width,
@@ -102,7 +102,7 @@ private fun AutoScrollingPager(
 @Composable
 private fun PopularSectionPreview() {
     val dummyMovies = List(5) {
-        PopularMovieItemUiState(
+        PopularMediaItemUiState(
             name = "Movie $it",
             posterUrl = "https://image.tmdb.org/t/p/w500/qmDpIHrmpJINaRKAfWQfftjCdyi.jpg",
             rating = (8.5f + it).toString()

--- a/ui/src/main/java/com/example/ui/screens/home/sections/topRatingSection.kt
+++ b/ui/src/main/java/com/example/ui/screens/home/sections/topRatingSection.kt
@@ -16,38 +16,43 @@ import com.example.designsystem.components.SectionTitle
 import com.example.designsystem.theme.AppTheme
 import com.example.ui.components.MovieCard
 import com.example.ui.screens.search.actorSearch.MovieImage
-import com.example.viewmodel.shared.uiStates.MovieItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaType
 
 fun LazyListScope.topRatingSection(
-    topRatedMovies: List<MovieItemUiState>, onClickMovie: (Long) -> Unit,
+    topRatedMediaItems: List<MediaItemUiState>, onClickMovie: (Long) -> Unit,
     onClickShowAll: () -> Unit
 ) {
     item {
-            SectionTitle(
-                title = stringResource(R.string.top_rating),
-                icon = painterResource(R.drawable.ic_fire),
-                tintColor = AppTheme.color.secondary,
-                modifier = Modifier
-                    .zIndex(1f)
-                    .padding(top = 24.dp, bottom = 12.dp),
-                showAllLabel = true,
-                onAllLabelClicked = onClickShowAll
-            )
+        SectionTitle(
+            title = stringResource(R.string.top_rating),
+            icon = painterResource(R.drawable.ic_fire),
+            tintColor = AppTheme.color.secondary,
+            modifier = Modifier
+                .zIndex(1f)
+                .padding(top = 24.dp, bottom = 12.dp),
+            showAllLabel = true,
+            onAllLabelClicked = onClickShowAll
+        )
     }
     item {
         LazyRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             contentPadding = PaddingValues(horizontal = 16.dp),
         ) {
-            items(topRatedMovies) { movie ->
+            items(topRatedMediaItems) { item ->
+                val movieType =
+                    if (item.mediaType == MediaType.MOVIE) stringResource(com.example.ui.R.string.movie)
+                    else stringResource(com.example.ui.R.string.tv)
+
                 MovieCard(
-                    movieImage = { MovieImage(movie.posterImageUrl) },
-                    movieType = stringResource(com.example.ui.R.string.movie),
-                    movieYear = movie.yearOfRelease,
-                    movieTitle = movie.name,
-                    movieRating = movie.rate
+                    movieImage = { MovieImage(item.posterImageUrl) },
+                    movieType = movieType,
+                    movieYear = item.yearOfRelease,
+                    movieTitle = item.name,
+                    movieRating = item.rate
                 ) {
-                    onClickMovie(movie.id)
+                    onClickMovie(item.id)
                 }
             }
         }

--- a/ui/src/main/java/com/example/ui/screens/topRated/TopRatedScreen.kt
+++ b/ui/src/main/java/com/example/ui/screens/topRated/TopRatedScreen.kt
@@ -31,7 +31,7 @@ import com.example.ui.components.appBar.DefaultAppBar
 import com.example.ui.navigation.Route
 import com.example.ui.screens.home.sections.AnimatedSectionVisibility
 import com.example.ui.screens.topRated.component.TopRatedBackgroundComponent
-import com.example.ui.screens.topRated.component.TopRatedMoviesGrid
+import com.example.ui.screens.topRated.component.TopRatedMediaItemsGrid
 import com.example.ui.utils.safeNavigate
 import com.example.viewmodel.topRated.TopRatedEffect
 import com.example.viewmodel.topRated.TopRatedInteractionListener
@@ -110,11 +110,11 @@ private fun TopRatedContent(
             }
 
             AnimatedSectionVisibility(
-                visible = state.topRatedMovies.isNotEmpty()
+                visible = state.topRatedMediaItems.isNotEmpty()
             ) {
-                TopRatedMoviesGrid(
+                TopRatedMediaItemsGrid(
                     gridState = gridState,
-                    topRatedMovies = state.topRatedMovies,
+                    items = state.topRatedMediaItems,
                     onClickMovie = interactionListener::onClickMovie,
                     modifier = Modifier.weight(1f).navigationBarsPadding()
                 )

--- a/ui/src/main/java/com/example/ui/screens/topRated/component/TopRatedMediaItemsGrid.kt
+++ b/ui/src/main/java/com/example/ui/screens/topRated/component/TopRatedMediaItemsGrid.kt
@@ -16,15 +16,16 @@ import com.example.designsystem.theme.AflamiTheme
 import com.example.designsystem.utils.ThemeAndLocalePreviews
 import com.example.ui.components.MovieCard
 import com.example.ui.screens.search.actorSearch.MovieImage
-import com.example.viewmodel.shared.uiStates.MovieItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaType
 
 @Composable
-fun TopRatedMoviesGrid(
-    topRatedMovies: List<MovieItemUiState>,
+fun TopRatedMediaItemsGrid(
+    items: List<MediaItemUiState>,
     onClickMovie: (Long) -> Unit,
     modifier: Modifier = Modifier,
     gridState: LazyGridState = rememberLazyGridState()
-    ) {
+) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
         state = gridState,
@@ -34,15 +35,19 @@ fun TopRatedMoviesGrid(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        items(topRatedMovies) { movie ->
+        items(items) { item ->
+            val movieType =
+                if (item.mediaType == MediaType.MOVIE) stringResource(com.example.ui.R.string.movie)
+                else stringResource(com.example.ui.R.string.tv)
+
             MovieCard(
-                movieImage = { MovieImage(movie.posterImageUrl) },
-                movieType = stringResource(com.example.ui.R.string.movie),
-                movieYear = movie.yearOfRelease,
-                movieTitle = movie.name,
-                movieRating = movie.rate
+                movieImage = { MovieImage(item.posterImageUrl) },
+                movieType = movieType,
+                movieYear = item.yearOfRelease,
+                movieTitle = item.name,
+                movieRating = item.rate
             ) {
-                onClickMovie(movie.id)
+                onClickMovie(item.id)
             }
         }
     }
@@ -53,7 +58,7 @@ fun TopRatedMoviesGrid(
 private fun TopRatedMoviesGridPreview() {
     AflamiTheme {
         val mockMovies = List(4) { index ->
-            MovieItemUiState(
+            MediaItemUiState(
                 id = index.toLong(),
                 name = "Movie $index",
                 posterImageUrl = "",
@@ -61,8 +66,8 @@ private fun TopRatedMoviesGridPreview() {
                 rate = (7 + index * 0.5).toString()
             )
         }
-        TopRatedMoviesGrid(
-            topRatedMovies = mockMovies,
+        TopRatedMediaItemsGrid(
+            items = mockMovies,
             onClickMovie = {}
         )
     }

--- a/ui/src/main/res/values-ar/string.xml
+++ b/ui/src/main/res/values-ar/string.xml
@@ -28,6 +28,7 @@
     <string name="history">تاريخي</string>
     <string name="tv_movie">فيلم تلفزيوني</string>
     <string name="movie">فيلم</string>
+    <string name="tv">مسلسل تلفزيوني</string>
     <string name="war">حرب</string>
     <string name="mystery">غموض</string>
     <string name="thriller">إثارة</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="history">History</string>
     <string name="tv_movie">TV movie</string>
     <string name="movie">Movie</string>
+    <string name="tv">TV show</string>
     <string name="war">War</string>
     <string name="mystery">Mystery</string>
     <string name="thriller">Thriller</string>

--- a/viewModel/src/main/java/com/example/viewmodel/home/HomeUiState.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/home/HomeUiState.kt
@@ -4,22 +4,25 @@ import com.example.entity.category.MovieGenre
 import com.example.viewmodel.shared.defaultMovieGenres
 import com.example.viewmodel.shared.uiStates.MovieGenreItemUiState
 import com.example.viewmodel.shared.uiStates.MovieItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaType
 
 data class HomeUiState(
-    val popularMovies : List<PopularMovieItemUiState> = emptyList(),
-    val upcomingMovies : List<MovieItemUiState> = emptyList(),
+    val popularMediaItems: List<PopularMediaItemUiState> = emptyList(),
+    val topRatedMediaItems: List<MediaItemUiState> = emptyList(),
+    val upcomingMovies: List<MovieItemUiState> = emptyList(),
     val upcomingMovieGenres: List<MovieGenreItemUiState> = defaultMovieGenres,
-    val topRatedMovies : List<MovieItemUiState> = emptyList(),
-    val isLoading : Boolean = false,
-    val error : HomeError? = null
-){
-    data class PopularMovieItemUiState(
-        val name : String = "",
-        val rating: String = "" ,
-        val posterUrl : String = ""
+    val isLoading: Boolean = false,
+    val error: HomeError? = null
+) {
+    data class PopularMediaItemUiState(
+        val name: String = "",
+        val rating: String = "",
+        val posterUrl: String = "",
+        val type: MediaType = MediaType.MOVIE
     )
 
-    sealed class HomeError{
+    sealed class HomeError {
         data object NetworkError : HomeError()
     }
 

--- a/viewModel/src/main/java/com/example/viewmodel/home/HomeUiStateMapper.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/home/HomeUiStateMapper.kt
@@ -3,29 +3,98 @@ package com.example.viewmodel.home
 import android.annotation.SuppressLint
 import com.example.domain.useCase.GetHomeScreenDataUseCase
 import com.example.entity.Movie
+import com.example.entity.TvShow
+import com.example.viewmodel.home.HomeUiState.PopularMediaItemUiState
 import com.example.viewmodel.shared.uiStates.MovieItemUiState
-import com.example.viewmodel.home.HomeUiState.PopularMovieItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaType
+import com.example.viewmodel.utils.getMixedMediaItemsList
 
 class HomeUiStateMapper {
 
     @SuppressLint("DefaultLocale")
     fun toUiState(homeScreenData: GetHomeScreenDataUseCase.HomeScreenData): HomeUiState {
         return HomeUiState(
-            popularMovies = moviesToPopularMoviesUiState(homeScreenData.popularMovies),
-            topRatedMovies = moviesToMoviesItemsUiState(homeScreenData.topRatedMovies),
-            upcomingMovies =  moviesToMoviesItemsUiState(homeScreenData.upComingMovies)
+            popularMediaItems = getPopularMediaItems(
+                homeScreenData.popularMovies,
+                homeScreenData.popularTvShows
+            ),
+            topRatedMediaItems = getTopRatedMediaItems(
+                homeScreenData.topRatedMovies,
+                homeScreenData.topRatedTvShows
+            ),
+            upcomingMovies = moviesToMoviesItemsUiState(homeScreenData.upComingMovies)
         )
     }
 
-    fun moviesToPopularMoviesUiState(movies: List<Movie>) = movies.map(::movieToPopularMovieUiState)
+    private fun getPopularMediaItems(
+        popularMovies: List<Movie>,
+        popularTvShows: List<TvShow>
+    ): List<PopularMediaItemUiState> {
+        return getMixedMediaItemsList(
+            popularMovies,
+            popularTvShows,
+            ::movieToPopularMediaItemUiState,
+            ::tvShowToPopularMediaItemUiState
+        )
+    }
+
+    private fun getTopRatedMediaItems(
+        topRatedMovies: List<Movie>,
+        topRatedTvShows: List<TvShow>
+    ): List<MediaItemUiState> {
+        return getMixedMediaItemsList(
+            topRatedMovies,
+            topRatedTvShows,
+            ::movieToTopRatedMediaItemUiState,
+            ::tvShowToTopRatedMediaItemUiState
+        )
+    }
+
+
     fun moviesToMoviesItemsUiState(movies: List<Movie>) = movies.map(::movieToMovieItemUiState)
 
     @SuppressLint("DefaultLocale")
-    private fun movieToPopularMovieUiState(movie: Movie): PopularMovieItemUiState {
-        return PopularMovieItemUiState(
+    private fun movieToPopularMediaItemUiState(movie: Movie): PopularMediaItemUiState {
+        return PopularMediaItemUiState(
             name = movie.name,
             rating = String.format("%.1f", movie.rating),
-            posterUrl = movie.posterUrl
+            posterUrl = movie.posterUrl,
+            type = MediaType.MOVIE
+        )
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun tvShowToPopularMediaItemUiState(tvShow: TvShow): PopularMediaItemUiState {
+        return PopularMediaItemUiState(
+            name = tvShow.name,
+            rating = String.format("%.1f", tvShow.rating),
+            posterUrl = tvShow.posterUrl,
+            type = MediaType.TV_SHOW
+        )
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun movieToTopRatedMediaItemUiState(movie: Movie): MediaItemUiState {
+        return MediaItemUiState(
+            id = movie.id,
+            name = movie.name,
+            rate = String.format("%.1f", movie.rating),
+            posterImageUrl = movie.posterUrl,
+            yearOfRelease = movie.releaseDate.year.toString(),
+            mediaType = MediaType.MOVIE
+        )
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun tvShowToTopRatedMediaItemUiState(tvShow: TvShow): MediaItemUiState {
+        return MediaItemUiState(
+            id = tvShow.id,
+            name = tvShow.name,
+            rate = String.format("%.1f", tvShow.rating),
+            posterImageUrl = tvShow.posterUrl,
+            yearOfRelease = tvShow.airDate.year.toString(),
+            mediaType = MediaType.TV_SHOW
         )
     }
 
@@ -39,5 +108,4 @@ class HomeUiStateMapper {
             yearOfRelease = movie.releaseDate.year.toString()
         )
     }
-
 }

--- a/viewModel/src/main/java/com/example/viewmodel/shared/uiStates/media/MediaItemUiState.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/shared/uiStates/media/MediaItemUiState.kt
@@ -1,0 +1,10 @@
+package com.example.viewmodel.shared.uiStates.media
+
+data class MediaItemUiState(
+        val id: Long = 0,
+        val name: String = "",
+        val posterImageUrl: String = "",
+        val yearOfRelease: String = "",
+        val rate: String = "",
+        val mediaType: MediaType = MediaType.MOVIE
+    )

--- a/viewModel/src/main/java/com/example/viewmodel/shared/uiStates/media/MediaType.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/shared/uiStates/media/MediaType.kt
@@ -1,0 +1,5 @@
+package com.example.viewmodel.shared.uiStates.media
+
+enum class MediaType {
+    MOVIE, TV_SHOW
+}

--- a/viewModel/src/main/java/com/example/viewmodel/topRated/TopRatedUiState.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/topRated/TopRatedUiState.kt
@@ -1,13 +1,13 @@
 package com.example.viewmodel.topRated
 
-import com.example.viewmodel.shared.uiStates.MovieItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaItemUiState
 
 data class TopRatedUiState(
-    val topRatedMovies: List<MovieItemUiState> = emptyList(),
+    val topRatedMediaItems: List<MediaItemUiState> = emptyList(),
     val isLoading: Boolean = false,
     val error: TopRatedError? = null
-){
-    sealed class TopRatedError{
+) {
+    sealed class TopRatedError {
         data object NetworkError : TopRatedError()
     }
 }

--- a/viewModel/src/main/java/com/example/viewmodel/topRated/TopRatedUiStateMapper.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/topRated/TopRatedUiStateMapper.kt
@@ -1,26 +1,57 @@
 package com.example.viewmodel.topRated
 
 import android.annotation.SuppressLint
+import com.example.domain.useCase.GetTopRatedScreenDataUseCase.TopRatedScreenData
 import com.example.entity.Movie
-import com.example.viewmodel.shared.uiStates.MovieItemUiState
+import com.example.entity.TvShow
+import com.example.viewmodel.shared.uiStates.media.MediaItemUiState
+import com.example.viewmodel.shared.uiStates.media.MediaType
+import com.example.viewmodel.utils.getMixedMediaItemsList
 
 class TopRatedUiStateMapper {
     @SuppressLint("DefaultLocale")
-    fun toUiState(topRatedMovies: List<Movie>): TopRatedUiState {
+    fun toUiState(topRatedScreenData: TopRatedScreenData): TopRatedUiState {
         return TopRatedUiState(
-            topRatedMovies = moviesToMoviesItemsUiState(topRatedMovies)
+            topRatedMediaItems = getTopRatedMediaItems(
+                topRatedScreenData.topRatedMovies,
+                topRatedScreenData.topRatedTvShows
+            )
         )
     }
-    fun moviesToMoviesItemsUiState(movies: List<Movie>) = movies.map(::movieToMovieItemUiState)
+
+    private fun getTopRatedMediaItems(
+        topRatedMovies: List<Movie>,
+        topRatedTvShows: List<TvShow>
+    ): List<MediaItemUiState> {
+        return getMixedMediaItemsList(
+            topRatedMovies,
+            topRatedTvShows,
+            ::movieToTopRatedMediaItemUiState,
+            ::tvShowToTopRatedMediaItemUiState
+        )
+    }
 
     @SuppressLint("DefaultLocale")
-    fun movieToMovieItemUiState(movie: Movie): MovieItemUiState {
-        return MovieItemUiState(
+    private fun movieToTopRatedMediaItemUiState(movie: Movie): MediaItemUiState {
+        return MediaItemUiState(
             id = movie.id,
             name = movie.name,
             rate = String.format("%.1f", movie.rating),
             posterImageUrl = movie.posterUrl,
-            yearOfRelease = movie.releaseDate.year.toString()
+            yearOfRelease = movie.releaseDate.year.toString(),
+            mediaType = MediaType.MOVIE
+        )
+    }
+
+    @SuppressLint("DefaultLocale")
+    private fun tvShowToTopRatedMediaItemUiState(tvShow: TvShow): MediaItemUiState {
+        return MediaItemUiState(
+            id = tvShow.id,
+            name = tvShow.name,
+            rate = String.format("%.1f", tvShow.rating),
+            posterImageUrl = tvShow.posterUrl,
+            yearOfRelease = tvShow.airDate.year.toString(),
+            mediaType = MediaType.TV_SHOW
         )
     }
 }

--- a/viewModel/src/main/java/com/example/viewmodel/topRated/TopRatedViewModel.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/topRated/TopRatedViewModel.kt
@@ -2,34 +2,34 @@ package com.example.viewmodel.topRated
 
 import com.example.domain.exceptions.AflamiException
 import com.example.domain.exceptions.NoInternetException
-import com.example.domain.useCase.GetTopRatedMoviesUseCase
-import com.example.entity.Movie
+import com.example.domain.useCase.GetTopRatedScreenDataUseCase
+import com.example.domain.useCase.GetTopRatedScreenDataUseCase.TopRatedScreenData
 import com.example.viewmodel.shared.BaseViewModel
 import com.example.viewmodel.topRated.TopRatedUiState.TopRatedError
 import com.example.viewmodel.utils.dispatcher.DispatcherProvider
 
 class TopRatedViewModel(
-    private val getTopRatedMoviesUseCase: GetTopRatedMoviesUseCase,
+    private val getTopRatedScreenDataUseCase: GetTopRatedScreenDataUseCase,
     private val topRatedUiStateMapper: TopRatedUiStateMapper,
     dispatcherProvider: DispatcherProvider
 ) : BaseViewModel<TopRatedUiState, TopRatedEffect>(TopRatedUiState(), dispatcherProvider),
     TopRatedInteractionListener {
 
     init {
-        getTopRatedMovies()
+        getTopRatedScreenData()
     }
 
-    private fun getTopRatedMovies() {
+    private fun getTopRatedScreenData() {
         updateState { it.copy(isLoading = true) }
         tryToExecute(
-            action = { getTopRatedMoviesUseCase() },
+            action = { getTopRatedScreenDataUseCase() },
             onSuccess = ::onGetTopRatedMoviesSuccess,
             onError = ::onError
         )
     }
 
-    private fun onGetTopRatedMoviesSuccess(topRatedMovies: List<Movie>) {
-        updateState { topRatedUiStateMapper.toUiState(topRatedMovies) }
+    private fun onGetTopRatedMoviesSuccess(topRatedScreenData: TopRatedScreenData) {
+        updateState { topRatedUiStateMapper.toUiState(topRatedScreenData) }
     }
 
     private fun onError(exception: AflamiException) {
@@ -40,6 +40,7 @@ class TopRatedViewModel(
                     error = TopRatedError.NetworkError
                 )
             }
+
             else ->
                 updateState {
                     it.copy(
@@ -54,7 +55,7 @@ class TopRatedViewModel(
     }
 
     override fun onClickRetryLoading() {
-        getTopRatedMovies()
+        getTopRatedScreenData()
     }
 
     override fun onClickBack() {

--- a/viewModel/src/main/java/com/example/viewmodel/utils/CollectionExtensions.kt
+++ b/viewModel/src/main/java/com/example/viewmodel/utils/CollectionExtensions.kt
@@ -1,0 +1,16 @@
+package com.example.viewmodel.utils
+
+fun <T, R, C> getMixedMediaItemsList(
+        listA: List<T>,
+        listB: List<R>,
+        transformA: (T) -> C,
+        transformB: (R) -> C,
+    ): List<C> {
+        val combinedList = listA.map(transformA) + listB.map(transformB)
+        val combinedListBackward = listB.map(transformB) + listA.map(transformA)
+
+        return combinedList
+            .shuffled()
+            .takeUnless { it == combinedListBackward || it == combinedListBackward }
+            ?: getMixedMediaItemsList(listA, listB, transformA, transformB)
+    }


### PR DESCRIPTION
## Description
This PR integrates TV shows alongside movies in the home and top-rated sections.

## Changes Made
- Updated Home and Top-Rated screens to display a mix of movies and TV shows.
- Introduced `MediaItemUiState` and `MediaType` to handle both movies and TV shows uniformly.
- Created `GetPopularTvShowsUseCase` and `GetTopRatedTvShowsUseCase` to fetch TV show data.
- Implemented `GetTopRatedScreenDataUseCase` to fetch combined movie and TV show data for the top-rated screen.
- Modified `GetHomeScreenDataUseCase` to include popular and top-rated TV shows.
- Added `getMixedMediaItemsList` utility function to shuffle and combine lists of different media types.
- Updated UI components (`PopularMediaItemCard`, `TopRatedMediaItemsGrid`) to support generic media items.
- Added "TV show" string resource.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---