### PR TITLE
Change category mapping from extension functions to regular functions

### DIFF
--- a/repository/src/main/java/com/example/repository/mapper/local/MovieGenreLocalMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/local/MovieGenreLocalMapper.kt
@@ -3,10 +3,10 @@ package com.example.repository.mapper.local
 import com.example.entity.category.MovieGenre
 import com.example.repository.dto.local.LocalMovieCategoryDto
 import com.example.repository.mapper.shared.EntityMapper
-import com.example.repository.mapper.shared.toMovieCategory
+import com.example.repository.mapper.shared.mapCategoryIdToMovieGenre
 
 class MovieGenreLocalMapper : EntityMapper<LocalMovieCategoryDto, MovieGenre> {
     override fun toEntity(dto: LocalMovieCategoryDto): MovieGenre {
-        return dto.categoryId.toMovieCategory()
+        return mapCategoryIdToMovieGenre(dto.categoryId)
     }
 }

--- a/repository/src/main/java/com/example/repository/mapper/local/TvShowGenreLocalMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/local/TvShowGenreLocalMapper.kt
@@ -3,10 +3,10 @@ package com.example.repository.mapper.local
 import com.example.entity.category.TvShowGenre
 import com.example.repository.dto.local.LocalTvShowCategoryDto
 import com.example.repository.mapper.shared.EntityMapper
-import com.example.repository.mapper.shared.toTvShowCategory
+import com.example.repository.mapper.shared.mapCategoryIdToTvShowGenre
 
 class TvShowGenreLocalMapper : EntityMapper<LocalTvShowCategoryDto, TvShowGenre> {
     override fun toEntity(dto: LocalTvShowCategoryDto): TvShowGenre {
-        return dto.categoryId.toTvShowCategory()
+        return mapCategoryIdToTvShowGenre(dto.categoryId)
     }
 }

--- a/repository/src/main/java/com/example/repository/mapper/remote/MovieRemoteMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/remote/MovieRemoteMapper.kt
@@ -4,7 +4,7 @@ import com.example.entity.Movie
 import com.example.entity.category.MovieGenre
 import com.example.repository.dto.remote.RemoteMovieItemDto
 import com.example.repository.mapper.shared.EntityMapper
-import com.example.repository.mapper.shared.toMovieCategory
+import com.example.repository.mapper.shared.mapCategoryIdToMovieGenre
 import kotlinx.datetime.toLocalDate
 
 class MovieRemoteMapper() : EntityMapper<RemoteMovieItemDto, Movie> {
@@ -26,6 +26,6 @@ class MovieRemoteMapper() : EntityMapper<RemoteMovieItemDto, Movie> {
     }
 
     private fun mapGenreIdsToCategories(genreIds: List<Int>): List<MovieGenre> {
-        return genreIds.map { it.toLong().toMovieCategory() }
+        return genreIds.map { mapCategoryIdToMovieGenre(it.toLong()) }
     }
 }

--- a/repository/src/main/java/com/example/repository/mapper/remote/TvShowDetailsRemoteMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/remote/TvShowDetailsRemoteMapper.kt
@@ -3,7 +3,7 @@ package com.example.repository.mapper.remote
 import com.example.entity.TvShow
 import com.example.repository.dto.remote.TvShowDetailsRemoteResponse
 import com.example.repository.mapper.shared.EntityMapper
-import com.example.repository.mapper.shared.toTvShowCategory
+import com.example.repository.mapper.shared.mapCategoryIdToTvShowGenre
 import kotlinx.datetime.toLocalDate
 
 class TvShowDetailsRemoteMapper() : EntityMapper<TvShowDetailsRemoteResponse, TvShow> {
@@ -14,7 +14,7 @@ class TvShowDetailsRemoteMapper() : EntityMapper<TvShowDetailsRemoteResponse, Tv
             description = dto.overview,
             posterUrl = dto.fullPosterPath.orEmpty(),
             airDate = dto.releaseDate.toLocalDate(),
-            categories = dto.genres.map { it.id.toLong().toTvShowCategory() },
+            categories = dto.genres.map { mapCategoryIdToTvShowGenre(it.id.toLong()) },
             rating = dto.voteAverage.toFloat(),
             popularity = dto.popularity,
             seasonCount = dto.seasonCount,

--- a/repository/src/main/java/com/example/repository/mapper/remote/TvShowRemoteMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/remote/TvShowRemoteMapper.kt
@@ -4,7 +4,7 @@ import com.example.entity.TvShow
 import com.example.entity.category.TvShowGenre
 import com.example.repository.dto.remote.RemoteTvShowItemDto
 import com.example.repository.mapper.shared.EntityMapper
-import com.example.repository.mapper.shared.toTvShowCategory
+import com.example.repository.mapper.shared.mapCategoryIdToTvShowGenre
 import kotlinx.datetime.toLocalDate
 
 class TvShowRemoteMapper() : EntityMapper<RemoteTvShowItemDto, TvShow> {
@@ -24,6 +24,6 @@ class TvShowRemoteMapper() : EntityMapper<RemoteTvShowItemDto, TvShow> {
     }
 
     private fun mapGenreIdsToCategories(genreIds: List<Int>): List<TvShowGenre> {
-        return genreIds.map { it.toLong().toTvShowCategory() }
+        return genreIds.map { mapCategoryIdToTvShowGenre(it.toLong()) }
     }
 }

--- a/repository/src/main/java/com/example/repository/mapper/remoteToLocal/MovieGenreIdsRemoteLocalMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/remoteToLocal/MovieGenreIdsRemoteLocalMapper.kt
@@ -1,16 +1,15 @@
 package com.example.repository.mapper.remoteToLocal
 
 import com.example.repository.dto.local.LocalMovieCategoryDto
-import com.example.repository.dto.local.LocalTvShowCategoryDto
 import com.example.repository.mapper.shared.RemoteToLocalMapper
-import com.example.repository.mapper.shared.toMovieCategory
+import com.example.repository.mapper.shared.mapCategoryIdToMovieGenre
 
 class MovieGenreIdsRemoteLocalMapper :
     RemoteToLocalMapper<Int, LocalMovieCategoryDto> {
     override fun toLocal(remote: Int, args: List<Any>): LocalMovieCategoryDto {
         return LocalMovieCategoryDto(
             categoryId = remote.toLong(),
-            name = remote.toLong().toMovieCategory().name,
+            name = mapCategoryIdToMovieGenre(remote.toLong()).name,
             storedLanguage = args.first().toString(),
         )
     }

--- a/repository/src/main/java/com/example/repository/mapper/remoteToLocal/TvShowGenreIdsRemoteLocalMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/remoteToLocal/TvShowGenreIdsRemoteLocalMapper.kt
@@ -2,14 +2,14 @@ package com.example.repository.mapper.remoteToLocal
 
 import com.example.repository.dto.local.LocalTvShowCategoryDto
 import com.example.repository.mapper.shared.RemoteToLocalMapper
-import com.example.repository.mapper.shared.toTvShowCategory
+import com.example.repository.mapper.shared.mapCategoryIdToTvShowGenre
 
 class TvShowGenreIdsRemoteLocalMapper :
     RemoteToLocalMapper<Int, LocalTvShowCategoryDto> {
     override fun toLocal(remote: Int, args: List<Any>): LocalTvShowCategoryDto {
         return LocalTvShowCategoryDto(
             categoryId = remote.toLong(),
-            name = remote.toLong().toTvShowCategory().name,
+            name = mapCategoryIdToTvShowGenre(remote.toLong()).name,
             storedLanguage = args.first().toString(),
         )
     }

--- a/repository/src/main/java/com/example/repository/mapper/shared/GenreMapper.kt
+++ b/repository/src/main/java/com/example/repository/mapper/shared/GenreMapper.kt
@@ -3,8 +3,8 @@ package com.example.repository.mapper.shared
 import com.example.entity.category.MovieGenre
 import com.example.entity.category.TvShowGenre
 
-fun Long.toMovieCategory(): MovieGenre {
-    return when (this) {
+fun mapCategoryIdToMovieGenre(genreId: Long): MovieGenre {
+    return when (genreId) {
         28L -> MovieGenre.ACTION
         12L -> MovieGenre.ADVENTURE
         16L -> MovieGenre.ANIMATION
@@ -28,8 +28,8 @@ fun Long.toMovieCategory(): MovieGenre {
     }
 }
 
-fun Long.toTvShowCategory(): TvShowGenre {
-    return when (this) {
+fun mapCategoryIdToTvShowGenre(genreId: Long): TvShowGenre {
+    return when (genreId) {
         10759L -> TvShowGenre.ACTION_ADVENTURE
         16L -> TvShowGenre.ANIMATION
         35L -> TvShowGenre.COMEDY


### PR DESCRIPTION
## Description
The extension functions `toMovieCategory()` and `toTvShowCategory()` have been changed to normal functions `mapCategoryIdToMovieGenre()` and `mapCategoryIdToTvShowGenre()` respectively.

This change clarifies the purpose of these functions, indicating they are responsible for mapping a category ID to a specific genre enum

All usages of the old function names have been updated to reflect this change.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.