### PR TITLE
Fix: Pagination loading issue

### DIFF
--- a/viewModel/src/main/java/com/example/paging/PagingSource.kt
+++ b/viewModel/src/main/java/com/example/paging/PagingSource.kt
@@ -19,7 +19,7 @@ class PagingSource<T : Any>(
             LoadResult.Page(
                 data,
                 prevKey = if (page == 1) null else page - 1,
-                nextKey = page + 1,
+                nextKey = if (data.isEmpty()) null else page + 1,
             )
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
## Description
The `nextKey` in `PagingSource.LoadResult.Page` is now set to `null` if the fetched `data` is empty. This prevents further attempts to load non-existent pages.
---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---