### PR TITLE
feature: use specific image widths for posters and backdrops

### DIFF
--- a/repository/build.gradle.kts
+++ b/repository/build.gradle.kts
@@ -2,7 +2,8 @@ import java.util.Properties
 
 val properties = Properties()
 properties.load(project.rootProject.file("local.properties").inputStream())
-val baseImageUrl: String = properties.getProperty("baseImageUrl") ?: ""
+val baseImageUrlWidth500: String = properties.getProperty("baseImageUrlWidth500") ?: ""
+val baseImageUrlWidth300: String = properties.getProperty("baseImageUrlWidth300") ?: ""
 
 plugins {
     alias(libs.plugins.android.library)
@@ -25,8 +26,14 @@ android {
 
         buildConfigField(
             "String",
-            "BASE_IMAGE_URL",
-            baseImageUrl
+            "BASE_IMAGE_URL_W500",
+            baseImageUrlWidth500
+        )
+
+        buildConfigField(
+            "String",
+            "BASE_IMAGE_URL_W300",
+            baseImageUrlWidth300
         )
     }
 }

--- a/repository/build.gradle.kts
+++ b/repository/build.gradle.kts
@@ -1,10 +1,3 @@
-import java.util.Properties
-
-val properties = Properties()
-properties.load(project.rootProject.file("local.properties").inputStream())
-val baseImageUrlWidth500: String = properties.getProperty("baseImageUrlWidth500") ?: ""
-val baseImageUrlWidth300: String = properties.getProperty("baseImageUrlWidth300") ?: ""
-
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -23,18 +16,6 @@ android {
     defaultConfig {
         testInstrumentationRunnerArguments["runnerBuilder"] =
             "de.mannodermaus.junit5.AndroidJUnit5Builder"
-
-        buildConfigField(
-            "String",
-            "BASE_IMAGE_URL_W500",
-            baseImageUrlWidth500
-        )
-
-        buildConfigField(
-            "String",
-            "BASE_IMAGE_URL_W300",
-            baseImageUrlWidth300
-        )
     }
 }
 

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeDto.kt
@@ -17,5 +17,5 @@ data class EpisodeDto(
     @SerialName("season_number") val seasonNumber: Int,
 ) {
     val fullStillPath: String?
-        get() = stillPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = stillPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeDto.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -17,5 +17,5 @@ data class EpisodeDto(
     @SerialName("season_number") val seasonNumber: Int,
 ) {
     val fullStillPath: String?
-        get() = stillPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = stillPath?.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeResponse.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeResponse.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,5 +16,5 @@ data class EpisodeResponse(
     @SerialName("vote_average") val voteAverage: Double,
 ) {
     val fullPosterPath: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = posterPath?.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeResponse.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/EpisodeResponse.kt
@@ -16,5 +16,5 @@ data class EpisodeResponse(
     @SerialName("vote_average") val voteAverage: Double,
 ) {
     val fullPosterPath: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/ProductionCompanyDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/ProductionCompanyDto.kt
@@ -16,5 +16,5 @@ data class ProductionCompanyDto(
     val originCountry: String
 ){
     val fullLogoPath: String?
-        get() = logoPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = logoPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/ProductionCompanyDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/ProductionCompanyDto.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,5 +16,5 @@ data class ProductionCompanyDto(
     val originCountry: String
 ){
     val fullLogoPath: String?
-        get() = logoPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = logoPath?.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCastDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCastDto.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -43,5 +43,5 @@ data class RemoteCastDto(
     val order: Int
 ){
     val fullProfilePath: String?
-        get() = profilePath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = profilePath.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCastDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCastDto.kt
@@ -43,5 +43,5 @@ data class RemoteCastDto(
     val order: Int
 ){
     val fullProfilePath: String?
-        get() = profilePath.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = profilePath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCrewDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCrewDto.kt
@@ -40,5 +40,5 @@ data class RemoteCrewDto(
     val job: String
 ){
     val fullProfilePath: String?
-        get() = profilePath.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = profilePath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCrewDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteCrewDto.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -40,5 +40,5 @@ data class RemoteCrewDto(
     val job: String
 ){
     val fullProfilePath: String?
-        get() = profilePath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = profilePath.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteMovieItemDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteMovieItemDto.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W300
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -25,8 +26,8 @@ data class RemoteMovieItemDto(
     @SerialName("genres") val genres: List<RemoteCategoryDto> = emptyList()
 ){
     val fullPosterUrl: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = posterPath?.let { BASE_IMAGE_URL_W500 + it }
 
     val fullBackdropUrl: String?
-        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL_W300 + it }
+        get() = backdropPath?.let { BASE_IMAGE_URL_W300 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteMovieItemDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteMovieItemDto.kt
@@ -25,8 +25,8 @@ data class RemoteMovieItemDto(
     @SerialName("genres") val genres: List<RemoteCategoryDto> = emptyList()
 ){
     val fullPosterUrl: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 
     val fullBackdropUrl: String?
-        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL_W300 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteTvShowItemDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteTvShowItemDto.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W300
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -24,7 +25,7 @@ data class RemoteTvShowItemDto(
     @SerialName("number_of_seasons") val seasonCount: Int = 0,
 ){
     val fullPosterPath: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = posterPath?.let { BASE_IMAGE_URL_W500 + it }
     val fullBackdropPath: String?
-        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL_W300 + it }
+        get() = backdropPath?.let { BASE_IMAGE_URL_W300 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteTvShowItemDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/RemoteTvShowItemDto.kt
@@ -24,7 +24,7 @@ data class RemoteTvShowItemDto(
     @SerialName("number_of_seasons") val seasonCount: Int = 0,
 ){
     val fullPosterPath: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
     val fullBackdropPath: String?
-        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL_W300 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/TvShowDetailsRemoteResponse.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/TvShowDetailsRemoteResponse.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.repository.dto.remote
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W300
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,8 +24,8 @@ data class TvShowDetailsRemoteResponse(
     @SerialName("number_of_seasons") val seasonCount: Int = 0,
 ) {
     val fullPosterPath: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = posterPath?.let { BASE_IMAGE_URL_W500 + it }
 
     val fullBackdropPath: String?
-        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL_W300 + it }
+        get() = backdropPath?.let { BASE_IMAGE_URL_W300 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/TvShowDetailsRemoteResponse.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/TvShowDetailsRemoteResponse.kt
@@ -23,8 +23,8 @@ data class TvShowDetailsRemoteResponse(
     @SerialName("number_of_seasons") val seasonCount: Int = 0,
 ) {
     val fullPosterPath: String?
-        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = posterPath?.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 
     val fullBackdropPath: String?
-        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = backdropPath?.let { BuildConfig.BASE_IMAGE_URL_W300 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/movieGallery/GalleryImageDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/movieGallery/GalleryImageDto.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote.movieGallery
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,5 +15,5 @@ data class GalleryImageDto(
     @SerialName("width") val width: Int
 ){
     val fullFilePath: String?
-        get() = filePath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = filePath.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/movieGallery/GalleryImageDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/movieGallery/GalleryImageDto.kt
@@ -15,5 +15,5 @@ data class GalleryImageDto(
     @SerialName("width") val width: Int
 ){
     val fullFilePath: String?
-        get() = filePath.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = filePath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/review/AuthorDetailsDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/review/AuthorDetailsDto.kt
@@ -1,6 +1,6 @@
 package com.amsterdam.repository.dto.remote.review
 
-import com.amsterdam.repository.BuildConfig
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,5 +16,5 @@ data class AuthorDetailsDto(
     val rating: Float? = null
 ){
     val fullAvatarPath: String?
-        get() = avatarPath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
+        get() = avatarPath.let { BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/dto/remote/review/AuthorDetailsDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/remote/review/AuthorDetailsDto.kt
@@ -16,5 +16,5 @@ data class AuthorDetailsDto(
     val rating: Float? = null
 ){
     val fullAvatarPath: String?
-        get() = avatarPath.let { BuildConfig.BASE_IMAGE_URL + it }
+        get() = avatarPath.let { BuildConfig.BASE_IMAGE_URL_W500 + it }
 }

--- a/repository/src/main/java/com/amsterdam/repository/mapper/remote/MovieRemoteMapper.kt
+++ b/repository/src/main/java/com/amsterdam/repository/mapper/remote/MovieRemoteMapper.kt
@@ -8,13 +8,19 @@ import com.amsterdam.repository.mapper.shared.mapCategoryIdToMovieGenre
 import com.amsterdam.repository.utils.toSafeLocalDate
 
 class MovieRemoteMapper() : EntityMapper<RemoteMovieItemDto, Movie> {
+
     override fun toEntity(dto: RemoteMovieItemDto): Movie {
+        return  toEntity(dto,isPoster = true)
+    }
+
+    fun toEntity(dto: RemoteMovieItemDto,isPoster : Boolean): Movie {
         val genresIds = dto.genreIds.ifEmpty { dto.genres.map { it.id } }
+        val imageUrl = if (isPoster) dto.fullPosterUrl else dto.fullBackdropUrl
         return Movie(
             id = dto.id,
             name = dto.title,
             description = dto.overview,
-            posterUrl = dto.fullPosterUrl.orEmpty(),
+            posterUrl = imageUrl.orEmpty(),
             releaseDate = dto.releaseDate.toSafeLocalDate(),
             categories = mapGenreIdsToCategories(genresIds),
             rating = dto.voteAverage.toFloat(),
@@ -23,6 +29,10 @@ class MovieRemoteMapper() : EntityMapper<RemoteMovieItemDto, Movie> {
             runTime = dto.runtime,
             hasVideo = dto.video
         )
+    }
+
+    fun toEntityList(dtoList: List<RemoteMovieItemDto>,isPoster: Boolean): List<Movie> {
+        return dtoList.map { toEntity(it, isPoster) }
     }
 
     private fun mapGenreIdsToCategories(genreIds: List<Int>): List<MovieGenre> {

--- a/repository/src/main/java/com/amsterdam/repository/mapper/remote/PostersRemoteMapper.kt
+++ b/repository/src/main/java/com/amsterdam/repository/mapper/remote/PostersRemoteMapper.kt
@@ -1,12 +1,12 @@
 package com.amsterdam.repository.mapper.remote
 
-import com.amsterdam.repository.BuildConfig
 import com.amsterdam.repository.dto.remote.movieGallery.RemoteGalleryResponse
 import com.amsterdam.repository.mapper.shared.EntityMapper
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 
 class PostersRemoteMapper : EntityMapper<RemoteGalleryResponse, List<String>> {
 
     override fun toEntity(dto: RemoteGalleryResponse): List<String> =
-        dto.posters.map { BuildConfig.BASE_IMAGE_URL_W500 + it.filePath }
+        dto.posters.map { BASE_IMAGE_URL_W500 + it.filePath }
 
 }

--- a/repository/src/main/java/com/amsterdam/repository/mapper/remote/PostersRemoteMapper.kt
+++ b/repository/src/main/java/com/amsterdam/repository/mapper/remote/PostersRemoteMapper.kt
@@ -7,6 +7,6 @@ import com.amsterdam.repository.mapper.shared.EntityMapper
 class PostersRemoteMapper : EntityMapper<RemoteGalleryResponse, List<String>> {
 
     override fun toEntity(dto: RemoteGalleryResponse): List<String> =
-        dto.posters.map { BuildConfig.BASE_IMAGE_URL + it.filePath }
+        dto.posters.map { BuildConfig.BASE_IMAGE_URL_W500 + it.filePath }
 
 }

--- a/repository/src/main/java/com/amsterdam/repository/mapper/remote/TvShowRemoteMapper.kt
+++ b/repository/src/main/java/com/amsterdam/repository/mapper/remote/TvShowRemoteMapper.kt
@@ -9,11 +9,16 @@ import com.amsterdam.repository.utils.toSafeLocalDate
 
 class TvShowRemoteMapper() : EntityMapper<RemoteTvShowItemDto, TvShow> {
     override fun toEntity(dto: RemoteTvShowItemDto): TvShow {
+       return toEntity(dto, true)
+    }
+
+    fun toEntity(dto: RemoteTvShowItemDto,isPoster : Boolean): TvShow {
+        val imageUrl = if (isPoster) dto.fullPosterPath else dto.fullBackdropPath
         return TvShow(
             id = dto.id,
             name = dto.title,
             description = dto.overview,
-            posterUrl = dto.fullPosterPath.orEmpty(),
+            posterUrl = imageUrl.orEmpty(),
             airDate = dto.releaseDate.toSafeLocalDate(),
             categories = mapGenreIdsToCategories(dto.genreIds),
             rating = dto.voteAverage.toFloat(),
@@ -21,6 +26,10 @@ class TvShowRemoteMapper() : EntityMapper<RemoteTvShowItemDto, TvShow> {
             seasonCount = dto.seasonCount,
             originCountry = dto.originCountry.firstOrNull() ?: "",
         )
+    }
+
+    fun toEntityList(dtoList: List<RemoteTvShowItemDto>,isPoster: Boolean): List<TvShow> {
+        return dtoList.map { toEntity(it, isPoster) }
     }
 
     private fun mapGenreIdsToCategories(genreIds: List<Int>): List<TvShowGenre> {

--- a/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
@@ -126,7 +126,7 @@ class MovieRepositoryImpl(
     }
 
     override suspend fun getSimilarMovies(movieId: Long): List<Movie> {
-        return movieRemoteMapper.toEntityList(movieRemoteDataSource.getSimilarMovies(movieId).results)
+        return movieRemoteMapper.toEntityList(movieRemoteDataSource.getSimilarMovies(movieId).results,isPoster = false)
     }
 
     override suspend fun getMovieGallery(movieId: Long): List<String> {
@@ -143,7 +143,7 @@ class MovieRepositoryImpl(
     }
 
     override suspend fun getUpcomingMovies(): List<Movie> {
-        return movieRemoteMapper.toEntityList(movieRemoteDataSource.getUpcomingMovies().results)
+        return movieRemoteMapper.toEntityList(movieRemoteDataSource.getUpcomingMovies().results,isPoster = false)
     }
 
     override suspend fun getPopularMovies(): List<Movie> =

--- a/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
@@ -113,7 +113,7 @@ class TvShowRepositoryImpl(
     }
 
     override suspend fun getSimilarTvShows(tvShowId: Long): List<TvShow> {
-        return tvRemoteMapper.toEntityList(remoteTvDataSource.getSimilarTvShows(tvShowId).results)
+        return tvRemoteMapper.toEntityList(remoteTvDataSource.getSimilarTvShows(tvShowId).results,)
     }
 
     override suspend fun getTvShowGallery(tvShowId: Long): List<String> {

--- a/repository/src/main/java/com/amsterdam/repository/utils/ImageBaseUrlsConstant.kt
+++ b/repository/src/main/java/com/amsterdam/repository/utils/ImageBaseUrlsConstant.kt
@@ -1,0 +1,6 @@
+package com.amsterdam.repository.utils
+
+object ImageBaseUrlsConstant {
+    const val BASE_IMAGE_URL_W500 = "https://image.tmdb.org/t/p/w500"
+    const val BASE_IMAGE_URL_W300 = "https://image.tmdb.org/t/p/w300"
+}

--- a/repository/src/test/java/com/amsterdam/repository/mapper/remote/CastRemoteMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/remote/CastRemoteMapperTest.kt
@@ -1,8 +1,8 @@
 package com.amsterdam.repository.mapper.remote
 
 import com.amsterdam.entity.Gender
-import com.amsterdam.repository.BuildConfig
 import com.amsterdam.repository.mapper.remote.testFactory.createRemoteCastDto
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 class CastRemoteMapperTest {
 
     private lateinit var mapper: CastRemoteMapper
-    private val baseImageUrl = BuildConfig.BASE_IMAGE_URL
 
     @BeforeEach
     fun setUp() {
@@ -38,7 +37,7 @@ class CastRemoteMapperTest {
         val dto = createRemoteCastDto(profilePath = "/actor.jpg")
         val result = mapper.toEntity(dto)
 
-        assertThat(result.imageUrl).isEqualTo("$baseImageUrl/actor.jpg")
+        assertThat(result.imageUrl).isEqualTo("$BASE_IMAGE_URL_W500/actor.jpg")
     }
 
     @Test
@@ -46,7 +45,7 @@ class CastRemoteMapperTest {
         val dto = createRemoteCastDto(profilePath = "")
         val result = mapper.toEntity(dto)
 
-        assertThat(result.imageUrl).isEqualTo(baseImageUrl)
+        assertThat(result.imageUrl).isEqualTo(BASE_IMAGE_URL_W500)
     }
 
     @Test
@@ -64,7 +63,7 @@ class CastRemoteMapperTest {
         assertThat(result.id).isEqualTo(999)
         assertThat(result.name).isEqualTo("Test Actor")
         assertThat(result.gender).isEqualTo(Gender.Male)
-        assertThat(result.imageUrl).isEqualTo("$baseImageUrl/test.jpg")
+        assertThat(result.imageUrl).isEqualTo("$BASE_IMAGE_URL_W500/test.jpg")
         assertThat(result.popularity).isEqualTo(123.45)
     }
 }

--- a/repository/src/test/java/com/amsterdam/repository/mapper/remote/ProductionCompanyRemoteMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/remote/ProductionCompanyRemoteMapperTest.kt
@@ -1,8 +1,8 @@
 package com.amsterdam.repository.mapper.remote
 
 import com.amsterdam.entity.ProductionCompany
-import com.amsterdam.repository.BuildConfig
 import com.amsterdam.repository.mapper.remote.testFactory.createProductionCompanyDto
+import com.amsterdam.repository.utils.ImageBaseUrlsConstant.BASE_IMAGE_URL_W500
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class ProductionCompanyRemoteMapperTest {
     @Test
     fun `toEntity should correctly map ProductionCompanyDto to ProductionCompany`() {
         val logoPath = "/logo.png"
-        val fullPath = BuildConfig.BASE_IMAGE_URL + logoPath
+        val fullPath = BASE_IMAGE_URL_W500 + logoPath
 
         val dto = createProductionCompanyDto(
             id = 101,


### PR DESCRIPTION
This commit updates the application to use different image widths for posters and backdrops.

- Posters will now use `BASE_IMAGE_URL_W500`.
- Backdrops will now use `BASE_IMAGE_URL_W300`.

This change is implemented across various DTOs and mappers to ensure consistency. The `MovieRemoteMapper` and `TvShowRemoteMapper` have been updated to accept an `isPoster` boolean to determine which image URL to use.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

- change in movie and tv show mapper 
- change in the dto to put different images size
- change the base image url to :
baseImageUrlWidth500 = "https://image.tmdb.org/t/p/w500"
baseImageUrlWidth300= "https://image.tmdb.org/t/p/w300"
<img width="1080" height="2400" alt="Screenshot_20250725_195230" src="https://github.com/user-attachments/assets/59613c16-b237-4490-bd36-c957380c9036" />
![Uploading Screenshot_20250725_195253.png…]()

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.