### PR TITLE
Fix/filtering section state & chips UI issue

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/chip/Chip.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/chip/Chip.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -48,10 +49,20 @@ fun Chip(
     val iconColor = if (isSelected) colors.iconSelectedColor else colors.iconUnselectedColor
     val labelColor = if (isSelected) colors.labelSelectedColor else colors.labelUnselectedColor
     val borderColor = if (isSelected) colors.borderSelectedColor else colors.borderUnselectedColor
+
+    val formattedLabel = remember(label) {
+        val words = label.split(" ")
+        if (words.size > 1) {
+            "${words.dropLast(1).joinToString(" ")}\n${words.last()}"
+        } else {
+            label
+        }
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier,
+        modifier = modifier.heightIn(min = 96.dp),
     ) {
         Box(
             modifier =
@@ -78,7 +89,7 @@ fun Chip(
             )
         }
         Text(
-            text = label,
+            text = formattedLabel,
             color = labelColor,
             style = AppTheme.textStyle.label.small,
             textAlign = TextAlign.Center,
@@ -92,13 +103,31 @@ fun Chip(
 @Composable
 private fun ChipPreview() {
     AflamiTheme {
-        Chip(
-            icon =
-                painterResource(
-                    R.drawable.ic_menu_square,
-                ),
-            label = "Documentary",
-            isSelected = true,
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Chip(
+                icon =
+                    painterResource(
+                        R.drawable.ic_menu_square,
+                    ),
+                label = "Science Fiction",
+                isSelected = true,
+            )
+            Chip(
+                icon =
+                    painterResource(
+                        R.drawable.ic_menu_square,
+                    ),
+                label = "Action",
+                isSelected = false,
+            )
+            Chip(
+                icon =
+                    painterResource(
+                        R.drawable.ic_menu_square,
+                    ),
+                label = "Action Adventure",
+                isSelected = false,
+            )
+        }
     }
 }

--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/chip/Chip.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/chip/Chip.kt
@@ -10,9 +10,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -25,11 +24,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.amsterdam.designsystem.R
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
@@ -53,36 +50,10 @@ fun Chip(
     val iconColor = if (isSelected) colors.iconSelectedColor else colors.iconUnselectedColor
     val labelColor = if (isSelected) colors.labelSelectedColor else colors.labelUnselectedColor
     val borderColor = if (isSelected) colors.borderSelectedColor else colors.borderUnselectedColor
-
-    val formattedLabel = remember(label) {
-        val words = label.split(" ")
-        if (words.size >= 2) {
-            "${words.first()}\n${words.drop(1).joinToString(" ")}"
-        } else {
-            label
-        }
-    }
-
-    val containsLongWord = remember(label) {
-        label.split(" ").any { it.length > 7 }
-    }
-
-    val baseTextStyle = AppTheme.textStyle.label.small
-
-    val currentTextStyle: TextStyle = remember(containsLongWord, baseTextStyle) {
-        if (containsLongWord) {
-            baseTextStyle.copy(fontSize = (9.25).sp)
-        } else {
-            baseTextStyle
-        }
-    }
-
-
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .heightIn(min = 96.dp)
+        modifier = modifier.width(70.dp),
     ) {
         Box(
             modifier =
@@ -109,13 +80,13 @@ fun Chip(
             )
         }
         Text(
-            text = formattedLabel,
+            text = label,
             color = labelColor,
-            style = currentTextStyle,
+            style = AppTheme.textStyle.label.small,
             textAlign = TextAlign.Center,
             maxLines = 2,
+            minLines = 2,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.widthIn(max = 90.dp)
         )
     }
 }

--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/chip/Chip.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/chip/Chip.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -23,9 +25,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.amsterdam.designsystem.R
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
@@ -52,17 +56,33 @@ fun Chip(
 
     val formattedLabel = remember(label) {
         val words = label.split(" ")
-        if (words.size > 1) {
-            "${words.dropLast(1).joinToString(" ")}\n${words.last()}"
+        if (words.size >= 2) {
+            "${words.first()}\n${words.drop(1).joinToString(" ")}"
         } else {
             label
         }
     }
 
+    val containsLongWord = remember(label) {
+        label.split(" ").any { it.length > 7 }
+    }
+
+    val baseTextStyle = AppTheme.textStyle.label.small
+
+    val currentTextStyle: TextStyle = remember(containsLongWord, baseTextStyle) {
+        if (containsLongWord) {
+            baseTextStyle.copy(fontSize = (9.25).sp)
+        } else {
+            baseTextStyle
+        }
+    }
+
+
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.heightIn(min = 96.dp),
+        modifier = modifier
+            .heightIn(min = 96.dp)
     ) {
         Box(
             modifier =
@@ -91,10 +111,11 @@ fun Chip(
         Text(
             text = formattedLabel,
             color = labelColor,
-            style = AppTheme.textStyle.label.small,
+            style = currentTextStyle,
             textAlign = TextAlign.Center,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = 90.dp)
         )
     }
 }
@@ -103,30 +124,31 @@ fun Chip(
 @Composable
 private fun ChipPreview() {
     AflamiTheme {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(18.dp)) {
             Chip(
-                icon =
-                    painterResource(
-                        R.drawable.ic_menu_square,
-                    ),
+                icon = painterResource(R.drawable.ic_menu_square),
                 label = "Science Fiction",
                 isSelected = true,
             )
             Chip(
-                icon =
-                    painterResource(
-                        R.drawable.ic_menu_square,
-                    ),
+                icon = painterResource(R.drawable.ic_menu_square),
                 label = "Action",
                 isSelected = false,
             )
             Chip(
-                icon =
-                    painterResource(
-                        R.drawable.ic_menu_square,
-                    ),
-                label = "Action Adventure",
+                icon = painterResource(R.drawable.ic_menu_square),
+                label = "Horror Thriller",
                 isSelected = false,
+            )
+            Chip(
+                icon = painterResource(R.drawable.ic_menu_square),
+                label = "FantasyAdventureMovieGenre",
+                isSelected = false,
+            )
+            Chip(
+                icon = painterResource(R.drawable.ic_menu_square),
+                label = "Short",
+                isSelected = true,
             )
         }
     }

--- a/designSystem/src/main/res/values/strings.xml
+++ b/designSystem/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="documentary">Documentary</string>
     <string name="animation">Animation</string>
     <string name="crime">Crime</string>
-    <string name="science_fiction">Science fiction</string>
+    <string name="science_fiction">Science Fiction</string>
     <string name="science_fiction_fantasy">Sci-Fi &amp; Fantasy</string>
     <string name="music">Music</string>
     <string name="horror">Horror</string>

--- a/entity/src/main/java/com/amsterdam/entity/category/MovieGenre.kt
+++ b/entity/src/main/java/com/amsterdam/entity/category/MovieGenre.kt
@@ -2,7 +2,6 @@ package com.amsterdam.entity.category
 
 enum class MovieGenre {
     ALL,
-    ROMANCE,
     SCIENCE_FICTION,
     FAMILY,
     MYSTERY,
@@ -13,12 +12,13 @@ enum class MovieGenre {
     COMEDY,
     HORROR,
     WESTERN,
-    MUSIC,
+    ROMANCE,
     ADVENTURE,
     TV_MOVIE,
     FANTASY,
     THRILLER,
     DRAMA,
-    DOCUMENTARY,
-    ANIMATION
+    ANIMATION,
+    MUSIC,
+    DOCUMENTARY
 }

--- a/entity/src/main/java/com/amsterdam/entity/category/TvShowGenre.kt
+++ b/entity/src/main/java/com/amsterdam/entity/category/TvShowGenre.kt
@@ -3,19 +3,19 @@ package com.amsterdam.entity.category
 enum class TvShowGenre {
     ALL,
     SCIENCE_FICTION_FANTASY,
-    ACTION_ADVENTURE,
     CRIME,
     FAMILY,
     MYSTERY,
     WAR_POLITICS,
     ANIMATION,
     COMEDY,
-    DOCUMENTARY,
     DRAMA,
     KIDS,
     NEWS,
+    ACTION_ADVENTURE,
     REALITY,
     SOAP,
     TALK,
     WESTERN,
+    DOCUMENTARY
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/SearchScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/SearchScreen.kt
@@ -97,6 +97,7 @@ internal fun SearchScreen(viewModel: SearchViewModel = koinViewModel()) {
                         viewModel.onSaveSearchHistory()
                         navController.safeNavigate(MovieDetails(effect.movieId))
                     }
+
                     is SearchUiEffect.NavigateToTvShowDetails -> {
                         viewModel.onSaveSearchHistory()
                         navController.navigate(SeriesDetails(effect.tvShowId))
@@ -162,8 +163,15 @@ private fun SearchContent(
             modifier = Modifier.align(Alignment.CenterHorizontally),
             visible = state.isDialogVisible,
         ) {
+            val currentFilterState =
+                if (state.selectedTabOption == TabOption.MOVIES) {
+                    state.movieFilterItemUiState
+                } else {
+                    state.tvShowFilterItemUiState
+                }
+
             FilterDialog(
-                filterState = state.filterItemUiState,
+                filterState = currentFilterState,
                 selectedTabOption = state.selectedTabOption,
                 interaction = filterInteraction
             )
@@ -301,7 +309,7 @@ private fun SuccessMediaItems(
                         movieYear = mediaItem.yearOfRelease,
                         movieTitle = mediaItem.name,
                         movieRating = mediaItem.rate,
-                        onClick = {onTvShowClicked(mediaItem.id)}
+                        onClick = { onTvShowClicked(mediaItem.id) }
                     )
                 }
             }
@@ -330,7 +338,7 @@ private fun getItemKey(
 ): String {
     val item = selectedItems[index]
     val id = if (selectedTabOption == TabOption.MOVIES) (item as MovieItemUiState).id
-             else (item as TvShowItemUiState).id
+    else (item as TvShowItemUiState).id
     return "${id}-${index}"
 }
 

--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/filterDialog/FilterDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/filterDialog/FilterDialog.kt
@@ -83,7 +83,8 @@ internal fun FilterDialog(
                     .background(
                         color = AppTheme.color.surface,
                         shape = RoundedCornerShape(12.dp),
-                    ).verticalScroll(rememberScrollState())
+                    )
+                    .verticalScroll(rememberScrollState())
                     .padding(vertical = 12.dp),
         ) {
             Row(
@@ -96,7 +97,6 @@ internal fun FilterDialog(
                 Text(
                     text = stringResource(R.string.filter_result),
                     color = AppTheme.color.title,
-                    fontStyle = AppTheme.textStyle.title.large.fontStyle,
                     style = AppTheme.textStyle.title.large,
                     modifier =
                         Modifier
@@ -105,7 +105,7 @@ internal fun FilterDialog(
 
                 IconButton(
                     painter = painterResource(R.drawable.ic_cancel),
-                    contentDescription = null,
+                    contentDescription = "",
                     onClick = interaction::onClickCancel,
                     tint = AppTheme.color.title,
                 )
@@ -113,7 +113,6 @@ internal fun FilterDialog(
             Text(
                 text = stringResource(R.string.imdb_rating),
                 color = AppTheme.color.title,
-                fontStyle = AppTheme.textStyle.title.small.fontStyle,
                 style = AppTheme.textStyle.title.small,
                 modifier =
                     Modifier
@@ -127,7 +126,6 @@ internal fun FilterDialog(
             Text(
                 text = stringResource(R.string.genre),
                 color = AppTheme.color.title,
-                fontStyle = AppTheme.textStyle.title.small.fontStyle,
                 style = AppTheme.textStyle.title.small,
                 modifier =
                     Modifier
@@ -141,7 +139,7 @@ internal fun FilterDialog(
                 state = lazyState,
                 contentPadding = PaddingValues(horizontal = 18.dp),
                 horizontalArrangement = Arrangement.spacedBy(18.dp),
-                verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.Top,
             ) {
                 when (selectedTabOption) {
                     TabOption.MOVIES -> {
@@ -220,7 +218,7 @@ private fun RatingBar(
                                 R.drawable.ic_outlined_star
                             },
                     ),
-                contentDescription = null,
+                contentDescription = "",
                 tint = AppTheme.color.yellowAccent,
                 modifier =
                     Modifier

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -34,7 +34,7 @@
     <string name="documentary">Documentary</string>
     <string name="animation">Animation</string>
     <string name="crime">Crime</string>
-    <string name="science_fiction">Science fiction</string>
+    <string name="science_fiction">Science Fiction</string>
     <string name="science_fiction_fantasy">Sci-Fi &amp; Fantasy</string>
     <string name="music">Music</string>
     <string name="horror">Horror</string>

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchUiState.kt
@@ -19,7 +19,8 @@ data class SearchUiState(
     val movies: Flow<PagingData<MovieItemUiState>> = emptyFlow(),
     val tvShows: Flow<PagingData<TvShowItemUiState>> = emptyFlow(),
     val isDialogVisible: Boolean = false,
-    val filterItemUiState: FilterItemUiState = FilterItemUiState(),
+    val movieFilterItemUiState: FilterItemUiState = FilterItemUiState(),
+    val tvShowFilterItemUiState: FilterItemUiState = FilterItemUiState(),
     val isLoading: Boolean = false,
     val errorUiState: SearchErrorState? = null,
 )
@@ -38,7 +39,7 @@ data class FilterItemUiState(
     val isLoading: Boolean = false,
 ) {
     val hasFilterData: Boolean
-        get() = selectedStarIndex > 0 || selectableMovieGenres.any { it.selectableMovieGenre.isSelected }
+        get() = selectedStarIndex > 0 || selectableMovieGenres.any { it.selectableMovieGenre.isSelected } || selectableTvShowGenres.any { it.selectableTvShowGenre.isSelected }
 
     private companion object {
         val defaultTvShowGenres =

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
@@ -89,7 +89,7 @@ class SearchViewModel(
                     .cachedIn(viewModelScope)
             },
             onSuccess = ::onFetchMoviesSuccess,
-            onError = ::onFetchError,
+            onError = {},
         )
     }
 
@@ -117,7 +117,7 @@ class SearchViewModel(
                     .cachedIn(viewModelScope)
             },
             onSuccess = ::onFetchTvShowsSuccess,
-            onError = ::onFetchError,
+            onError = {},
         )
     }
 
@@ -142,10 +142,9 @@ class SearchViewModel(
                         }
                     },
                 ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }
-                    .cachedIn(viewModelScope)
             },
             onSuccess = ::onMoviesFilteredSuccess,
-            onError = ::onFetchError,
+            onError = {},
             onCompletion = ::onClickCancel,
         )
     }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
@@ -1,6 +1,5 @@
 package com.amsterdam.viewmodel.search.keywordSearch
 
-import android.R.attr.rating
 import androidx.lifecycle.viewModelScope
 import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
@@ -81,18 +80,20 @@ class SearchViewModel(
                             getAndFilterMoviesByKeywordUseCase(
                                 keyword = keyword,
                                 page = page,
+                                rating = state.value.movieFilterItemUiState.selectedStarIndex,
+                                movieGenre = state.value.movieFilterItemUiState.selectableMovieGenres.getSelectedGenreType()
                             )
                         }
                     },
-                ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }.cachedIn(viewModelScope)
+                ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }
+                    .cachedIn(viewModelScope)
             },
             onSuccess = ::onFetchMoviesSuccess,
-            onError = {},
+            onError = ::onFetchError,
         )
     }
 
     private fun onFetchMoviesSuccess(movies: Flow<PagingData<MovieItemUiState>>) {
-        applyMoviesFilter()
         updateState { it.copy(movies = movies) }
     }
 
@@ -107,24 +108,25 @@ class SearchViewModel(
                             getAndFilterTvShowsByKeywordUseCase(
                                 keyword = keyword,
                                 page = page,
-                                rating = rating,
+                                rating = state.value.tvShowFilterItemUiState.selectedStarIndex,
+                                tvGenre = state.value.tvShowFilterItemUiState.selectableTvShowGenres.getSelectedGenreType()
                             )
                         }
                     },
-                ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }.cachedIn(viewModelScope)
+                ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }
+                    .cachedIn(viewModelScope)
             },
             onSuccess = ::onFetchTvShowsSuccess,
-            onError = {},
+            onError = ::onFetchError,
         )
     }
 
     private fun onFetchTvShowsSuccess(tvShows: Flow<PagingData<TvShowItemUiState>>) {
-        applyTvShowsFilter()
         updateState { it.copy(tvShows = tvShows) }
     }
 
     private fun applyMoviesFilter() {
-        val currentCategoryItemUiStates = state.value.filterItemUiState.selectableMovieGenres
+        val currentMovieFilterState = state.value.movieFilterItemUiState
         tryToExecute(
             action = {
                 Pager(
@@ -134,12 +136,13 @@ class SearchViewModel(
                             getAndFilterMoviesByKeywordUseCase(
                                 keyword = state.value.keyword,
                                 page = page,
-                                rating = state.value.filterItemUiState.selectedStarIndex,
-                                movieGenre = currentCategoryItemUiStates.getSelectedGenreType(),
+                                rating = currentMovieFilterState.selectedStarIndex,
+                                movieGenre = currentMovieFilterState.selectableMovieGenres.getSelectedGenreType(),
                             )
                         }
                     },
-                ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }.cachedIn(viewModelScope)
+                ).flow.map { pagingData -> pagingData.map { it.toMediaItemUiState() } }
+                    .cachedIn(viewModelScope)
             },
             onSuccess = ::onMoviesFilteredSuccess,
             onError = ::onFetchError,
@@ -151,13 +154,13 @@ class SearchViewModel(
         updateState {
             it.copy(
                 movies = movies,
-                filterItemUiState = it.filterItemUiState.copy(isLoading = false),
+                movieFilterItemUiState = it.movieFilterItemUiState.copy(isLoading = false),
             )
         }
     }
 
     private fun applyTvShowsFilter() {
-        val currentGenreItemUiStates = state.value.filterItemUiState.selectableTvShowGenres
+        val currentTvShowFilterState = state.value.tvShowFilterItemUiState
         tryToExecute(
             action = {
                 Pager(
@@ -167,8 +170,8 @@ class SearchViewModel(
                             getAndFilterTvShowsByKeywordUseCase(
                                 keyword = state.value.keyword,
                                 page = page,
-                                rating = state.value.filterItemUiState.selectedStarIndex,
-                                tvGenre = currentGenreItemUiStates.getSelectedGenreType(),
+                                rating = currentTvShowFilterState.selectedStarIndex,
+                                tvGenre = currentTvShowFilterState.selectableTvShowGenres.getSelectedGenreType(),
                             )
                         }
                     },
@@ -187,7 +190,7 @@ class SearchViewModel(
         updateState {
             it.copy(
                 tvShows = tvShows,
-                filterItemUiState = it.filterItemUiState.copy(isLoading = false),
+                tvShowFilterItemUiState = it.tvShowFilterItemUiState.copy(isLoading = false),
             )
         }
     }
@@ -196,7 +199,14 @@ class SearchViewModel(
         updateState { it.copy(errorUiState = SearchErrorState.toSearchErrorState(exception)) }
     }
 
-    private fun resetFilterState() = updateState { it.copy(filterItemUiState = FilterItemUiState()) }
+    private fun resetFilterState() {
+        updateState { currentState ->
+            when (currentState.selectedTabOption) {
+                TabOption.MOVIES -> currentState.copy(movieFilterItemUiState = FilterItemUiState())
+                TabOption.TV_SHOWS -> currentState.copy(tvShowFilterItemUiState = FilterItemUiState())
+            }
+        }
+    }
 
     private fun startLoading() = updateState { it.copy(isLoading = true) }
 
@@ -233,10 +243,7 @@ class SearchViewModel(
         updateState {
             it.copy(
                 selectedTabOption = tabOption,
-                movies = state.value.movies,
-                tvShows = state.value.tvShows,
                 isLoading = true,
-                filterItemUiState = FilterItemUiState(),
             )
         }
         onSearchKeywordChanged(_keyword.value)
@@ -271,7 +278,8 @@ class SearchViewModel(
             currentState.copy(
                 keyword = "",
                 isDialogVisible = false,
-                filterItemUiState = FilterItemUiState(),
+                movieFilterItemUiState = FilterItemUiState(),
+                tvShowFilterItemUiState = FilterItemUiState(),
             )
         }
     }
@@ -314,16 +322,30 @@ class SearchViewModel(
     }
 
     override fun onChangeRatingStar(ratingIndex: Int) {
-        updateState { it.copy(filterItemUiState = it.filterItemUiState.copy(selectedStarIndex = ratingIndex)) }
+        updateState { currentState ->
+            when (currentState.selectedTabOption) {
+                TabOption.MOVIES -> currentState.copy(
+                    movieFilterItemUiState = currentState.movieFilterItemUiState.copy(
+                        selectedStarIndex = ratingIndex
+                    )
+                )
+
+                TabOption.TV_SHOWS -> currentState.copy(
+                    tvShowFilterItemUiState = currentState.tvShowFilterItemUiState.copy(
+                        selectedStarIndex = ratingIndex
+                    )
+                )
+            }
+        }
     }
 
     override fun onChangeMovieGenre(genreType: MovieGenre) {
         updateState {
             it.copy(
-                filterItemUiState =
-                    state.value.filterItemUiState.copy(
+                movieFilterItemUiState =
+                    state.value.movieFilterItemUiState.copy(
                         selectableMovieGenres =
-                            it.filterItemUiState.selectableMovieGenres.selectByMovieGenre(
+                            it.movieFilterItemUiState.selectableMovieGenres.selectByMovieGenre(
                                 genreType,
                             ),
                     ),
@@ -334,10 +356,10 @@ class SearchViewModel(
     override fun onChangeTvShowGenre(genreType: TvShowGenre) {
         updateState {
             it.copy(
-                filterItemUiState =
-                    state.value.filterItemUiState.copy(
+                tvShowFilterItemUiState =
+                    state.value.tvShowFilterItemUiState.copy(
                         selectableTvShowGenres =
-                            it.filterItemUiState.selectableTvShowGenres.selectByTvGenre(
+                            it.tvShowFilterItemUiState.selectableTvShowGenres.selectByTvGenre(
                                 genreType,
                             ),
                     ),
@@ -349,16 +371,22 @@ class SearchViewModel(
         updateState {
             it.copy(
                 isDialogVisible = false,
-                filterItemUiState = it.filterItemUiState.copy(isLoading = false),
+                movieFilterItemUiState = it.movieFilterItemUiState.copy(isLoading = false),
+                tvShowFilterItemUiState = it.tvShowFilterItemUiState.copy(isLoading = false),
             )
         }
     }
 
     override fun onClickApply() {
-        updateState {
-            it.copy(
-                filterItemUiState = it.filterItemUiState.copy(isLoading = true),
+        updateState { currentState ->
+            currentState.copy(
                 isDialogVisible = false,
+                movieFilterItemUiState = if (currentState.selectedTabOption == TabOption.MOVIES) currentState.movieFilterItemUiState.copy(
+                    isLoading = true
+                ) else currentState.movieFilterItemUiState,
+                tvShowFilterItemUiState = if (currentState.selectedTabOption == TabOption.TV_SHOWS) currentState.tvShowFilterItemUiState.copy(
+                    isLoading = true
+                ) else currentState.tvShowFilterItemUiState,
             )
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

- Fix Ui issues for the chip 
- Fix State of the filtering dialog

---

## Changes Made
List the changes introduced in this pull request:

-separate `FilterItemUiState` instances for movies and TV shows within the `SearchUiState`, previously a single `filterItemUiState` was used, which could lead to incorrect filtering behavior when switching between movie and TV show searches
-The `hasFilterData` property in `FilterItemUiState` has also been updated to consider selected TV show genres
- Implemented separate filter and rating states for movies and TV shows.
- Ensured that filter and rating selections are correctly applied when switching between movie and TV show tabs
- When applying filters, the loading state is now managed independently for movies and TV shows based on the selected tab
- Resetting filters now correctly clears the filter and rating state for the currently active tab (movies or TV shows)
- updating the `currentFilterState` based on the `selectedTabOption`.
- min lines for the text is 2 lines
- f in fiction is now capital to be as in the design
- reorder genres enums for ui related problems

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.