### PR TITLE
Move Basic Components to Design System

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/DesignSystem.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/DesignSystem.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.components.Icon
 import com.amsterdam.designsystem.components.RadioButton
 import com.amsterdam.designsystem.components.RadioState
-import com.amsterdam.designsystem.components.Score
 import com.amsterdam.designsystem.components.SectionTitle
 import com.amsterdam.designsystem.components.TabsLayout
 import com.amsterdam.designsystem.components.TextField
@@ -215,12 +214,6 @@ fun DesignSystem() {
         GenreChip(
             genre = stringResource(R.string.action),
             selected = true,
-        )
-        Score(
-            1,
-        )
-        Score(
-            -1,
         )
         SectionTitle(
             title = stringResource(R.string.movies_birthday),

--- a/designSystem/src/main/java/com/amsterdam/designsystem/TopAppBar.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/TopAppBar.kt
@@ -1,4 +1,4 @@
-package com.amsterdam.ui.components.appBar
+package com.amsterdam.designsystem
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -17,7 +17,6 @@ import com.amsterdam.designsystem.components.Icon
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
-import com.amsterdam.ui.R
 
 @Composable
 fun TopAppBar(
@@ -72,19 +71,19 @@ private fun TopAppBarPreview() {
             },
             leadingIcon = {
                 Icon(
-                    painter = painterResource(R.drawable.ic_filter_vertical),
+                    painter = painterResource(R.drawable.ic_outlined_add_to_favourite),
                     contentDescription = null,
                 )
             },
             middleIcon = {
                 Icon(
-                    painter = painterResource(R.drawable.ic_filter_vertical),
+                    painter = painterResource(R.drawable.ic_outlined_add_to_favourite),
                     contentDescription = null,
                 )
             },
             trailingIcon = {
                 Icon(
-                    painter = painterResource(R.drawable.ic_filter_vertical),
+                    painter = painterResource(R.drawable.ic_outlined_add_to_favourite),
                     contentDescription = null,
                 )
             },

--- a/ui/src/main/java/com/amsterdam/ui/components/appBar/DefaultAppBar.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/appBar/DefaultAppBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.R
+import com.amsterdam.designsystem.TopAppBar
 import com.amsterdam.designsystem.components.IconButton
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme

--- a/ui/src/main/java/com/amsterdam/ui/components/appBar/HomeAppBar.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/appBar/HomeAppBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.amsterdam.designsystem.TopAppBar
 import com.amsterdam.designsystem.components.IconButton
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme

--- a/ui/src/main/java/com/amsterdam/ui/screens/letsPlay/component/CircularGameScore.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/letsPlay/component/CircularGameScore.kt
@@ -1,22 +1,22 @@
-package com.amsterdam.designsystem.components
+package com.amsterdam.ui.screens.letsPlay.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 
 @Composable
-fun Score(
+fun CircularGameScore(
     score: Int,
     modifier: Modifier = Modifier,
 ) {
@@ -46,9 +46,9 @@ fun Score(
 private fun ScorePreview() {
     AflamiTheme {
         Column {
-            Score(score = -1)
-            Score(score = 1)
-            Score(score = 0)
+            CircularGameScore(score = -1)
+            CircularGameScore(score = 1)
+            CircularGameScore(score = 0)
         }
     }
 }


### PR DESCRIPTION
## Description

This PR moves the `TopAppBar` composable function from the `ui` module to the `designSystem` module. This change also involves renaming the `Score` composable to `CircularGameScore` and moving it to the `ui` module.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.