### PR TITLE
Update explore movies and shows padding

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/ExploreMoviesAndShows.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/ExploreMoviesAndShows.kt
@@ -21,7 +21,7 @@ import com.amsterdam.ui.R
 @Composable
 internal fun ExploreMoviesAndShows(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.padding(vertical = 8.dp, horizontal = 48.dp),
+        modifier = modifier.padding(horizontal = 48.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/ExploreMoviesAndShows.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/ExploreMoviesAndShows.kt
@@ -21,7 +21,7 @@ import com.amsterdam.ui.R
 @Composable
 internal fun ExploreMoviesAndShows(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier.padding(vertical = 8.dp),
+        modifier = modifier.padding(vertical = 8.dp, horizontal = 48.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -32,7 +32,7 @@ internal fun ExploreMoviesAndShows(modifier: Modifier = Modifier) {
         )
         Text(
             text = stringResource(R.string.search_description),
-            modifier = Modifier.padding(top = 8.dp),
+            modifier = Modifier.padding(top = 12.dp),
             style = AppTheme.textStyle.body.small,
             color = AppTheme.color.body,
             textAlign = TextAlign.Center,


### PR DESCRIPTION
## Description
Modified the padding for the "Explore Movies and Shows" section in the keyword search screen and the vertical padding was removed from the `ExploreMoviesAndShows` composable to avoid the cutting from bottom in small devices

---

## Screenshots (if applicable)
<img width="466" height="791" alt="Screenshot 2025-07-29 at 09 53 00" src="https://github.com/user-attachments/assets/b6da08c5-cbba-44f2-b6ab-063e7daf8740" />

<img width="447" height="952" alt="Screenshot 2025-07-29 at 13 49 48" src="https://github.com/user-attachments/assets/34c70396-2b6d-48b0-ae36-6272de7e4059" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.