### PR TITLE
Fix Cropped Text in Landscape Mode of SearchByActorScreen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/search/actorSearch/SearchByActorScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/actorSearch/SearchByActorScreen.kt
@@ -28,10 +28,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.CombinedLoadStates
 import androidx.paging.PagingData
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.amsterdam.designsystem.components.CenterOfScreenContainer
@@ -50,10 +50,10 @@ import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.components.appBar.DefaultAppBar
 import com.amsterdam.ui.navigation.Route
 import com.amsterdam.ui.utils.safeNavigate
-import com.amsterdam.viewmodel.search.actorSearch.ActorSearchErrorState
-import com.amsterdam.viewmodel.search.actorSearch.ActorSearchUiState
 import com.amsterdam.viewmodel.search.actorSearch.ActorSearchEffect
+import com.amsterdam.viewmodel.search.actorSearch.ActorSearchErrorState
 import com.amsterdam.viewmodel.search.actorSearch.ActorSearchInteractionListener
+import com.amsterdam.viewmodel.search.actorSearch.ActorSearchUiState
 import com.amsterdam.viewmodel.search.actorSearch.ActorSearchViewModel
 import com.amsterdam.viewmodel.shared.uiStates.MovieItemUiState
 import kotlinx.coroutines.flow.emptyFlow
@@ -137,7 +137,7 @@ private fun SearchByActorContent(
             },
             label = "Content Animation",
         ) { targetState ->
-            CenterOfScreenContainer(headerHeight) {
+            CenterOfScreenContainer(headerHeight + 100.dp) {
                 when {
                     targetState.isLoading -> LoadingContainer(modifier = Modifier)
 


### PR DESCRIPTION
## Description
The height of the `CenterOfScreenContainer` in `SearchByActorScreen.kt` has been increased by `100.dp` to prevent content from being hidden by the bottom navigation bar.

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
<img width="888" height="952" alt="Screenshot 2025-07-29 at 10 13 52" src="https://github.com/user-attachments/assets/7c0c68fa-314c-463c-a138-57fb95cf6cdb" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.