### PR TITLE
Fix/bottom navbar text overflows and survive in configuration changes

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/bottomNavBar/BottomNavBar.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/bottomNavBar/BottomNavBar.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
@@ -44,6 +46,9 @@ fun BottomNavBar(
                         text = stringResource(destination.key.label),
                         color = labelColor,
                         style = AppTheme.textStyle.label.small,
+                        maxLines = 1,
+                        textAlign = TextAlign.Center,
+                        overflow = TextOverflow.Ellipsis
                     )
                 },
                 icon = {

--- a/ui/src/main/java/com/amsterdam/ui/navigation/BottomNaviagtion.kt
+++ b/ui/src/main/java/com/amsterdam/ui/navigation/BottomNaviagtion.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
@@ -29,7 +30,7 @@ fun BottomNavigation(
     modifier: Modifier = Modifier,
 ) {
     val visible =
-        remember(currentDestination) {
+        rememberSaveable(currentDestination) {
             shouldShowBottomNavigation(currentDestination)
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description
Fix `bottomNavBar` visibility while configuration changes and fix `navBarItem` title overflows
---

## Changes Made
List the changes introduced in this pull request:

- visibility of `bottomNavBar` survives while configuration changes
- `navBarItem` has overflow ellipsis for large fonts

---

## Screenshots
<img width="412" height="88" alt="Screenshot 2025-07-29 144425" src="https://github.com/user-attachments/assets/c70f15d2-9869-4df1-ba8b-51fe020c7517" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.