### PR TITLE
Fix Cast section cutting scroll effect

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -246,36 +247,38 @@ fun MovieContent(
                                 .fillMaxWidth()
                                 .offset(y = (-20).dp),
                     ) {
-                        Column(
+                        Text(
+                            text = state.movieTitle,
+                            style = AppTheme.textStyle.title.large,
+                            color = AppTheme.color.title,
                             modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                        LazyRow(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            contentPadding = PaddingValues(horizontal = 16.dp)
                         ) {
-                            Text(
-                                text = state.movieTitle,
-                                style = AppTheme.textStyle.title.large,
-                                color = AppTheme.color.title,
-                            )
-                            LazyRow(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 12.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                items(state.categories) {
-                                    CategoryChip(categoryName = getMovieGenreLabel(it))
-                                }
+                            items(state.categories) {
+                                CategoryChip(categoryName = getMovieGenreLabel(it))
                             }
-                            MovieInfoSection(
-                                modifier = Modifier.padding(top = 8.dp),
-                                releaseDate = state.releaseDate,
-                                movieLength = state.movieLength,
-                                originCountry = state.originCountry,
-                            )
-                            DescriptionSection(
-                                modifier = Modifier.padding(top = 24.dp),
-                                description = state.description,
-                            )
                         }
+                        MovieInfoSection(
+                            modifier = Modifier
+                                .padding(top = 8.dp)
+                                .padding(horizontal = 16.dp),
+                            releaseDate = state.releaseDate,
+                            movieLength = state.movieLength,
+                            originCountry = state.originCountry,
+                        )
+                        DescriptionSection(
+                            modifier = Modifier
+                                .padding(top = 24.dp)
+                                .padding(horizontal = 16.dp),
+                            description = state.description,
+                        )
                         CastSection(
                             modifier = Modifier.padding(top = 24.dp),
                             actors = state.actors.take(10),

--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -44,7 +44,6 @@ import com.amsterdam.designsystem.R
 import com.amsterdam.designsystem.components.ImageErrorIndicator
 import com.amsterdam.designsystem.components.ImageLoadingIndicator
 import com.amsterdam.designsystem.components.LoadingContainer
-import com.amsterdam.ui.components.RatingChip
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
@@ -53,6 +52,7 @@ import com.amsterdam.imageviewer.ui.SafeImageView
 import com.amsterdam.ui.application.LocalNavController
 import com.amsterdam.ui.components.MustLoginDialog
 import com.amsterdam.ui.components.NoNetworkContainer
+import com.amsterdam.ui.components.RatingChip
 import com.amsterdam.ui.components.appBar.DefaultAppBar
 import com.amsterdam.ui.navigation.Route
 import com.amsterdam.ui.screens.movieDetails.components.CastSection
@@ -99,6 +99,7 @@ fun MovieDetailsScreen(viewModel: MovieDetailsViewModel = hiltViewModel()) {
                             )
                         )
                     }
+
                     MovieDetailsEffect.NavigateToLoginScreenEffect -> navController.safeNavigate(
                         Route.Login
                     )
@@ -243,35 +244,38 @@ fun MovieContent(
                         modifier =
                             Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
                                 .offset(y = (-20).dp),
                     ) {
-                        Text(
-                            text = state.movieTitle,
-                            style = AppTheme.textStyle.title.large,
-                            color = AppTheme.color.title,
-                        )
-                        LazyRow(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 12.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        Column(
+                            modifier = Modifier.padding(horizontal = 16.dp)
                         ) {
-                            items(state.categories) {
-                                CategoryChip(categoryName = getMovieGenreLabel(it))
+                            Text(
+                                text = state.movieTitle,
+                                style = AppTheme.textStyle.title.large,
+                                color = AppTheme.color.title,
+                            )
+                            LazyRow(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 12.dp),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                items(state.categories) {
+                                    CategoryChip(categoryName = getMovieGenreLabel(it))
+                                }
                             }
+                            MovieInfoSection(
+                                modifier = Modifier.padding(top = 8.dp),
+                                releaseDate = state.releaseDate,
+                                movieLength = state.movieLength,
+                                originCountry = state.originCountry,
+                            )
+                            DescriptionSection(
+                                modifier = Modifier.padding(top = 24.dp),
+                                description = state.description,
+                            )
                         }
-                        MovieInfoSection(
-                            modifier = Modifier.padding(top = 8.dp),
-                            releaseDate = state.releaseDate,
-                            movieLength = state.movieLength,
-                            originCountry = state.originCountry,
-                        )
-                        DescriptionSection(
-                            modifier = Modifier.padding(top = 24.dp),
-                            description = state.description,
-                        )
                         CastSection(
                             modifier = Modifier.padding(top = 24.dp),
                             actors = state.actors.take(10),
@@ -286,7 +290,9 @@ fun MovieContent(
                                     .background(AppTheme.color.stroke),
                         )
                         MovieExtrasSection(
-                            modifier = Modifier.padding(top = 12.dp),
+                            modifier = Modifier
+                                .padding(top = 12.dp)
+                                .padding(horizontal = 16.dp),
                             extras = state.extraItem,
                             onClickExtras = interactionListener::onClickMovieExtras,
                         )

--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/CastSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/CastSection.kt
@@ -1,8 +1,8 @@
 package com.amsterdam.ui.screens.movieDetails.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -13,8 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.R
-import com.amsterdam.designsystem.components.Text
-import com.amsterdam.designsystem.theme.AppTheme
+import com.amsterdam.designsystem.components.SectionTitle
 import com.amsterdam.viewmodel.shared.movieAndSeriseDetails.ActorUiState
 
 @Composable
@@ -28,21 +27,19 @@ fun CastSection(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(
-                text = stringResource(R.string.cast),
-                style = AppTheme.textStyle.headline.small,
-                color = AppTheme.color.title,
-            )
-            Text(
-                text = stringResource(R.string.all),
-                style = AppTheme.textStyle.label.medium,
-                color = AppTheme.color.primary,
-                modifier = Modifier.clickable(onClick = onClickAllCast)
+            SectionTitle(
+                title = stringResource(R.string.cast),
+                showAllLabel = true,
+                onAllLabelClicked = onClickAllCast,
+                modifier = Modifier.padding(bottom = 8.dp)
             )
         }
         LazyRow(
-            modifier = Modifier.padding(top = 8.dp).fillMaxWidth(),
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp)
         ) {
             items(actors) {
                 ActorCard(actor = it)

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -48,7 +48,6 @@ import com.amsterdam.designsystem.components.Icon
 import com.amsterdam.designsystem.components.ImageErrorIndicator
 import com.amsterdam.designsystem.components.ImageLoadingIndicator
 import com.amsterdam.designsystem.components.LoadingContainer
-import com.amsterdam.ui.components.RatingChip
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.components.chip.Chip
 import com.amsterdam.designsystem.components.divider.HorizontalDivider
@@ -60,6 +59,7 @@ import com.amsterdam.ui.application.LocalNavController
 import com.amsterdam.ui.components.EpisodeCard
 import com.amsterdam.ui.components.MustLoginDialog
 import com.amsterdam.ui.components.NoNetworkContainer
+import com.amsterdam.ui.components.RatingChip
 import com.amsterdam.ui.components.appBar.DefaultAppBar
 import com.amsterdam.ui.navigation.Route
 import com.amsterdam.ui.screens.movieDetails.components.CastSection
@@ -108,7 +108,10 @@ fun SeriesDetailsScreen(
                             )
                         )
                     }
-                    SeriesDetailsEffect.NavigateToLoginScreenEffect -> navController.safeNavigate(Route.Login)
+
+                    SeriesDetailsEffect.NavigateToLoginScreenEffect -> navController.safeNavigate(
+                        Route.Login
+                    )
                 }
             }
         }
@@ -188,7 +191,7 @@ fun SeriesDetailsContent(
     ) {
         Box(
             modifier = Modifier.fillMaxSize()
-        ){
+        ) {
             LazyColumn(
                 state = listState,
                 modifier = Modifier
@@ -239,34 +242,37 @@ fun SeriesDetailsContent(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp)
                                 .offset(y = (-20).dp)
                         ) {
-                            Text(
-                                text = state.title,
-                                style = AppTheme.textStyle.title.large,
-                                color = AppTheme.color.title
-                            )
-                            LazyRow(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 12.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            Column(
+                                modifier = Modifier.padding(horizontal = 16.dp)
                             ) {
-                                items(state.categories) {
-                                    CategoryChip(categoryName = getTvShowGenreLabel(it))
+                                Text(
+                                    text = state.title,
+                                    style = AppTheme.textStyle.title.large,
+                                    color = AppTheme.color.title
+                                )
+                                LazyRow(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 12.dp),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    items(state.categories) {
+                                        CategoryChip(categoryName = getTvShowGenreLabel(it))
+                                    }
                                 }
+                                SeriesInfoSection(
+                                    modifier = Modifier.padding(top = 8.dp),
+                                    airDate = state.airDate,
+                                    seasonCount = state.seasonCount,
+                                    originCountry = state.originCountry
+                                )
+                                DescriptionSection(
+                                    modifier = Modifier.padding(top = 24.dp),
+                                    description = state.description
+                                )
                             }
-                            SeriesInfoSection(
-                                modifier = Modifier.padding(top = 8.dp),
-                                airDate = state.airDate,
-                                seasonCount = state.seasonCount,
-                                originCountry = state.originCountry
-                            )
-                            DescriptionSection(
-                                modifier = Modifier.padding(top = 24.dp),
-                                description = state.description
-                            )
                             CastSection(
                                 modifier = Modifier.padding(top = 24.dp),
                                 actors = state.cast,
@@ -280,7 +286,9 @@ fun SeriesDetailsContent(
                                     .background(AppTheme.color.stroke)
                             )
                             SeriesExtrasSection(
-                                modifier = Modifier.padding(top = 12.dp),
+                                modifier = Modifier
+                                    .padding(top = 12.dp)
+                                    .padding(horizontal = 16.dp),
                                 extras = state.extraItem,
                                 onClickExtras = interaction::onClickSeriesExtraItem
                             )
@@ -295,7 +303,6 @@ fun SeriesDetailsContent(
                         when (selectedExtra) {
                             SeriesExtras.SEASONS -> seasonsSection(
                                 seasons = state.seasons,
-                                state = state,
                                 interaction = interaction
                             )
 
@@ -385,7 +392,6 @@ private fun SeriesExtrasSection(
 
 private fun LazyListScope.seasonsSection(
     seasons: List<SeasonUiState>,
-    state: SeriesDetailsUiState,
     interaction: SeriesDetailsInteractionListener
 ) {
     seasons.forEachIndexed { index, season ->
@@ -408,7 +414,7 @@ private fun LazyListScope.seasonsSection(
 private fun SeasonHeader(
     season: SeasonUiState,
     onClickSeasonMenu: (Int) -> Unit,
-    ) {
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -244,35 +245,38 @@ fun SeriesDetailsContent(
                                 .fillMaxWidth()
                                 .offset(y = (-20).dp)
                         ) {
-                            Column(
+
+                            Text(
+                                text = state.title,
+                                style = AppTheme.textStyle.title.large,
+                                color = AppTheme.color.title,
                                 modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                            LazyRow(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 12.dp),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                contentPadding = PaddingValues(horizontal = 16.dp)
                             ) {
-                                Text(
-                                    text = state.title,
-                                    style = AppTheme.textStyle.title.large,
-                                    color = AppTheme.color.title
-                                )
-                                LazyRow(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 12.dp),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                ) {
-                                    items(state.categories) {
-                                        CategoryChip(categoryName = getTvShowGenreLabel(it))
-                                    }
+                                items(state.categories) {
+                                    CategoryChip(categoryName = getTvShowGenreLabel(it))
                                 }
-                                SeriesInfoSection(
-                                    modifier = Modifier.padding(top = 8.dp),
-                                    airDate = state.airDate,
-                                    seasonCount = state.seasonCount,
-                                    originCountry = state.originCountry
-                                )
-                                DescriptionSection(
-                                    modifier = Modifier.padding(top = 24.dp),
-                                    description = state.description
-                                )
                             }
+                            SeriesInfoSection(
+                                modifier = Modifier
+                                    .padding(top = 8.dp)
+                                    .padding(horizontal = 16.dp),
+                                airDate = state.airDate,
+                                seasonCount = state.seasonCount,
+                                originCountry = state.originCountry,
+                            )
+                            DescriptionSection(
+                                modifier = Modifier
+                                    .padding(top = 24.dp)
+                                    .padding(horizontal = 24.dp),
+                                description = state.description
+                            )
                             CastSection(
                                 modifier = Modifier.padding(top = 24.dp),
                                 actors = state.cast,


### PR DESCRIPTION
## Description

This PR adjusts the padding in `MovieDetailsScreen.kt` and `SeriesDetailsScreen.kt` to ensure consistent horizontal spacing for various sections and fix Cast section cutting effect.

It also refactors `CastSection.kt` to utilize the `SectionTitle` composable for its header, improving code reuse and consistency.

---
## Screenshots (if applicable)
https://github.com/user-attachments/assets/227f0d38-ebc7-4bc0-b900-671480c7a7c6



---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---