### PR TITLE
Fix Back Navigation In Search Screen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/SearchScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/SearchScreen.kt
@@ -90,13 +90,17 @@ internal fun SearchScreen(viewModel: SearchViewModel = hiltViewModel()) {
         viewModel.effect.collectLatest { effect ->
             effect?.let {
                 when (effect) {
-                    SearchUiEffect.NavigateBack -> navController.popBackStack()
+                    SearchUiEffect.NavigateBack -> navController.popBackStack(
+                        route = Route.Tab.Home,
+                        inclusive = false,
+                    )
                     SearchUiEffect.NavigateToActorSearch -> navController.safeNavigate(Route.SearchByActor)
                     SearchUiEffect.NavigateToWorldSearch -> navController.safeNavigate(Route.SearchByCountry)
                     is SearchUiEffect.NavigateToMovieDetails -> {
                         viewModel.onSaveSearchHistory()
                         navController.safeNavigate(MovieDetails(effect.movieId))
                     }
+
                     is SearchUiEffect.NavigateToTvShowDetails -> {
                         viewModel.onSaveSearchHistory()
                         navController.navigate(SeriesDetails(effect.tvShowId))
@@ -301,7 +305,7 @@ private fun SuccessMediaItems(
                         movieYear = mediaItem.yearOfRelease,
                         movieTitle = mediaItem.name,
                         movieRating = mediaItem.rate,
-                        onClick = {onTvShowClicked(mediaItem.id)}
+                        onClick = { onTvShowClicked(mediaItem.id) }
                     )
                 }
             }
@@ -330,7 +334,7 @@ private fun getItemKey(
 ): String {
     val item = selectedItems[index]
     val id = if (selectedTabOption == TabOption.MOVIES) (item as MovieItemUiState).id
-             else (item as TvShowItemUiState).id
+    else (item as TvShowItemUiState).id
     return "${id}-${index}"
 }
 


### PR DESCRIPTION
## Description
The PR changes the navigation behavior in the SearchScreen. When a user navigates back from the search results, they are now taken to the Home screen instead of the previous screen in the back stack.

---

## Screenshots (if applicable)
https://github.com/user-attachments/assets/3fb9439d-1f3f-4554-88ff-ac8fc539eede


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.