### PR TITLE
refactor: make details screen extras scrollable

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -293,9 +293,7 @@ fun MovieContent(
                                     .background(AppTheme.color.stroke),
                         )
                         MovieExtrasSection(
-                            modifier = Modifier
-                                .padding(top = 12.dp)
-                                .padding(horizontal = 16.dp),
+                            modifier = Modifier.padding(top = 12.dp),
                             extras = state.extraItem,
                             onClickExtras = interactionListener::onClickMovieExtras,
                         )

--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/MovieExtrasSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/MovieExtrasSection.kt
@@ -1,9 +1,11 @@
 package com.amsterdam.ui.screens.movieDetails.components
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -20,8 +22,12 @@ fun MovieExtrasSection(
     onClickExtras: (MovieExtras) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        extras.forEach {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp)
+    ) {
+        items(items = extras) {
             val extrasSectionItemInfo = it.item.getExtrasSectionItemInfo()
             Chip(
                 modifier = Modifier.size(70.dp, 96.dp),

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -290,9 +290,7 @@ fun SeriesDetailsContent(
                                     .background(AppTheme.color.stroke)
                             )
                             SeriesExtrasSection(
-                                modifier = Modifier
-                                    .padding(top = 12.dp)
-                                    .padding(horizontal = 16.dp),
+                                modifier = Modifier.padding(top = 12.dp),
                                 extras = state.extraItem,
                                 onClickExtras = interaction::onClickSeriesExtraItem
                             )
@@ -380,8 +378,12 @@ private fun SeriesExtrasSection(
     extras: List<Selectable<SeriesExtras>>,
     onClickExtras: (SeriesExtras) -> Unit
 ) {
-    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        extras.forEach {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp)
+    ) {
+        items(items = extras) {
             val extrasSectionItemInfo = it.item.getSeriesExtrasSectionItemInfo()
             Chip(
                 modifier = Modifier.size(70.dp, 96.dp),


### PR DESCRIPTION
# Pull Request Template

## Description
fix problem of cutting details screen extras section and make it scrollable

---

## Changes Made
List the changes introduced in this pull request:

- make extras section scrollable
---

## Screenshots
![extras](https://github.com/user-attachments/assets/f35caafe-e7a7-4338-b395-509bab89ae37)

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.