### PR TITLE
Fix: login button and padding

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBar.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBar.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,19 +34,20 @@ import com.amsterdam.designsystem.utils.modifierExtensions.dropShadow
 fun BoxScope.SnackBar(
     message: String,
     status: SnackBarStatus,
+    modifier: Modifier = Modifier
 ) {
     val shape = RoundedCornerShape(12.dp)
     Box(
         modifier =
-            Modifier
+            modifier
                 .align(Alignment.TopCenter)
-                .padding(19.dp)
                 .fillMaxWidth()
                 .dropShadow(
                     blur = 8.dp,
                     shape = shape,
                     color = status.dropShadowColor(),
-                ).padding(1.dp)
+                )
+                .padding(1.dp)
                 .clip(shape = shape)
                 .clipToBounds()
                 .background(AppTheme.color.surfaceHigh, shape = shape)

--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarData.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarData.kt
@@ -1,0 +1,6 @@
+package com.amsterdam.designsystem.components.snackBar
+
+data class SnackBarData(
+    val message: String,
+    val status: SnackBarStatus,
+    val duration: Long = 3000L)

--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarHost.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarHost.kt
@@ -1,0 +1,67 @@
+package com.amsterdam.designsystem.components.snackBar
+
+import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.EaseInQuart
+import androidx.compose.animation.core.EaseOutQuart
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun BoxScope.SnackBarHost(
+    modifier: Modifier = Modifier
+) {
+    var currentSnackBar by remember { mutableStateOf<SnackBarData?>(null) }
+    var showSnackBar by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        SnackBarManager.snackBarFlow.collectLatest { snackBarData ->
+            currentSnackBar = snackBarData
+            showSnackBar = true
+
+            delay(snackBarData.duration)
+            showSnackBar = false
+
+            delay(300)
+            currentSnackBar = null
+        }
+    }
+
+    AnimatedVisibility(
+        visible = showSnackBar ,
+        enter = slideInVertically(
+            initialOffsetY = { -it },
+            animationSpec = tween(300, easing = EaseOutQuart)
+        ),
+        exit = slideOutVertically(
+            targetOffsetY = { -it },
+            animationSpec = tween(300, easing = EaseInQuart)
+        ),
+        modifier = modifier
+    ) {
+        currentSnackBar?.let { snackBar ->
+            SnackBar(
+                message = snackBar.message,
+                status = snackBar.status,
+                modifier = Modifier
+                    .statusBarsPadding()
+                    .padding(top = 16.dp)
+                    .padding(horizontal = 16.dp)
+            )
+        }
+    }
+}

--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarManager.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarManager.kt
@@ -16,6 +16,7 @@ object SnackBarManager {
         status: SnackBarStatus,
         duration: Long = 3000L
     ) {
+        if (message.isEmpty()) return
         val snackBarData = SnackBarData(message, status, duration)
         _snackBarFlow.tryEmit(snackBarData)
     }

--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarManager.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/snackBar/SnackBarManager.kt
@@ -1,0 +1,30 @@
+package com.amsterdam.designsystem.components.snackBar
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+object SnackBarManager {
+    private val _snackBarFlow = MutableSharedFlow<SnackBarData>(
+        extraBufferCapacity = 1
+    )
+    val snackBarFlow: SharedFlow<SnackBarData> = _snackBarFlow.asSharedFlow()
+
+    private fun show(
+        message: String,
+        status: SnackBarStatus,
+        duration: Long = 3000L
+    ) {
+        val snackBarData = SnackBarData(message, status, duration)
+        _snackBarFlow.tryEmit(snackBarData)
+    }
+
+    fun showSuccess(message: String, duration: Long = 3000L) {
+        show(message, SnackBarStatus.Success, duration)
+    }
+
+    fun showError(message: String, duration: Long = 3000L) {
+        show(message, SnackBarStatus.Failure, duration)
+    }
+}

--- a/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
+++ b/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
@@ -1,15 +1,19 @@
 package com.amsterdam.ui.application
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.amsterdam.designsystem.components.Scaffold
+import com.amsterdam.designsystem.components.snackBar.SnackBarHost
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.ui.navigation.BottomNavigation
 import com.amsterdam.ui.navigation.NavGraph
@@ -35,10 +39,13 @@ fun AflamiApp(
                     )
                 }
             ) {
-                NavGraph(
-                    navController = navController,
-                    startDestination = startDestination
-                )
+                Box(modifier = Modifier.fillMaxSize()) {
+                    NavGraph(
+                        navController = navController,
+                        startDestination = startDestination
+                    )
+                    SnackBarHost()
+                }
             }
         }
     }

--- a/ui/src/main/java/com/amsterdam/ui/screens/login/LoginScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/login/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.ui.screens.login
 
+import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -18,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
@@ -84,6 +86,7 @@ private fun LoginScreenContent(
     interactionListener: LoginInteractionListener
 ) {
     val scrollState = rememberScrollState()
+    val isLandscape = LocalConfiguration.current.orientation == ORIENTATION_LANDSCAPE
     Box {
         LoginBackground()
         Column(
@@ -103,7 +106,7 @@ private fun LoginScreenContent(
                     containerColor = AppTheme.color.primaryVariant,
                     paddingValues = PaddingValues(horizontal = 6.dp, vertical = 9.dp),
                     withBorder = true,
-                    modifier = Modifier.padding(bottom = 24.dp)
+                    modifier = Modifier.padding(vertical = 24.dp)
                 )
 
                 Text(
@@ -171,7 +174,12 @@ private fun LoginScreenContent(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 16.dp),
+                    .padding(bottom = 16.dp)
+                    .then(
+                        if (isLandscape){
+                            Modifier.padding(top = 32.dp)
+                        } else Modifier
+                    ),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/login/LoginScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/login/LoginScreen.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.ui.screens.login
 
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,9 +18,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
@@ -32,6 +37,7 @@ import com.amsterdam.designsystem.components.buttons.ButtonDefaults
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.designsystem.components.buttons.OutlinedButton
 import com.amsterdam.designsystem.components.buttons.PlainTextButton
+import com.amsterdam.designsystem.components.snackBar.SnackBarManager
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
@@ -39,16 +45,15 @@ import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavController
 import com.amsterdam.ui.navigation.Route
 import com.amsterdam.ui.screens.login.components.LoginBackground
-import com.amsterdam.ui.screens.login.components.getPasswordErrorMessage
+import com.amsterdam.ui.screens.login.components.getLoginErrorMessage
 import com.amsterdam.ui.screens.login.components.getPasswordTextFieldIcon
-import com.amsterdam.ui.screens.login.components.getUserNameErrorMessage
 import com.amsterdam.ui.utils.safeNavigate
-import com.amsterdam.ui.utils.safeNavigateToTab
 import com.amsterdam.viewmodel.login.LoginEffect
+import com.amsterdam.viewmodel.login.LoginErrorState
 import com.amsterdam.viewmodel.login.LoginInteractionListener
 import com.amsterdam.viewmodel.login.LoginUiState
 import com.amsterdam.viewmodel.login.LoginViewModel
-import com.amsterdam.viewmodel.login.PasswordErrorState
+import kotlinx.coroutines.delay
 
 @Composable
 fun LoginScreen(
@@ -56,7 +61,8 @@ fun LoginScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val navController = LocalNavController.current
-    val usernameOrPasswordError = stringResource(R.string.incorrect_username_or_password)
+    val context = LocalContext.current
+
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
             effect?.let {
@@ -69,6 +75,11 @@ fun LoginScreen(
 
                     LoginEffect.NavigateToRegister -> navController.safeNavigate(Route.Register)
                     LoginEffect.NavigateToResetPassword -> navController.safeNavigate(Route.ResetPassword)
+                    LoginEffect.ShowCredentialsError -> {
+                        SnackBarManager.showError(
+                            getLoginErrorMessage(state.loginError, context)
+                        )
+                    }
                 }
             }
         }
@@ -87,6 +98,11 @@ private fun LoginScreenContent(
 ) {
     val scrollState = rememberScrollState()
     val isLandscape = LocalConfiguration.current.orientation == ORIENTATION_LANDSCAPE
+    var show by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        delay(3000)
+        show = true
+    }
     Box {
         LoginBackground()
         Column(
@@ -125,8 +141,6 @@ private fun LoginScreenContent(
                     text = state.username,
                     onValueChange = interactionListener::onUserNameUpdated,
                     hintText = stringResource(R.string.user_name_hint),
-                    errorMessage = getUserNameErrorMessage(state.usernameError),
-                    isError = state.usernameError != null,
                     leadingIcon = com.amsterdam.designsystem.R.drawable.ic_user_square,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
@@ -134,8 +148,6 @@ private fun LoginScreenContent(
                     text = state.password,
                     onValueChange = interactionListener::onPasswordUpdate,
                     hintText = stringResource(R.string.password_hint),
-                    errorMessage = getPasswordErrorMessage(state.passwordError),
-                    isError = state.passwordError != null,
                     isTrailingClickEnabled = true,
                     onTrailingClick = interactionListener::onShowPasswordClicked,
                     leadingIcon = com.amsterdam.designsystem.R.drawable.ic_door_lock,
@@ -211,7 +223,7 @@ private fun LoginScreenContentPreview() {
         LoginScreenContent(
             state = LoginUiState(
                 password = "password",
-                passwordError = PasswordErrorState.InvalidCredentials,
+                loginError = LoginErrorState.InvalidCredentials,
             ),
             interactionListener = object : LoginInteractionListener {
                 override fun onUserNameUpdated(username: String) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/login/components/GetLoginErrorMessage.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/login/components/GetLoginErrorMessage.kt
@@ -1,23 +1,16 @@
 package com.amsterdam.ui.screens.login.components
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.amsterdam.ui.R
-import com.amsterdam.viewmodel.login.PasswordErrorState
-import com.amsterdam.viewmodel.login.UsernameErrorState
+import com.amsterdam.viewmodel.login.LoginErrorState
 
-@Composable
-fun getUserNameErrorMessage(usernameErrorState: UsernameErrorState?): String{
-    return when(usernameErrorState){
-        UsernameErrorState.InvalidCredentials -> stringResource(R.string.incorrect_username_or_password)
-        null -> ""
-    }
-}
-
-@Composable
-fun getPasswordErrorMessage(passwordErrorState: PasswordErrorState?): String{
-    return when(passwordErrorState){
-        PasswordErrorState.InvalidCredentials -> stringResource(R.string.incorrect_username_or_password)
+fun getLoginErrorMessage(loginErrorState: LoginErrorState?, context: Context): String{
+    return when(loginErrorState){
+        LoginErrorState.InvalidCredentials -> context.getString(R.string.incorrect_username_or_password)
+        LoginErrorState.AccountDisabled -> context.getString(R.string.account_disabled)
+        LoginErrorState.VerificationRequired -> context.getString(R.string.account_not_verified)
         null -> ""
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/login/components/GetLoginErrorMessage.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/login/components/GetLoginErrorMessage.kt
@@ -11,6 +11,8 @@ fun getLoginErrorMessage(loginErrorState: LoginErrorState?, context: Context): S
         LoginErrorState.InvalidCredentials -> context.getString(R.string.incorrect_username_or_password)
         LoginErrorState.AccountDisabled -> context.getString(R.string.account_disabled)
         LoginErrorState.VerificationRequired -> context.getString(R.string.account_not_verified)
-        null -> ""
+        LoginErrorState.NoInternet -> context.getString(R.string.offline_message)
+        LoginErrorState.UnknownError -> context.getString(R.string.search_error_unknown)
+        else -> ""
     }
 }

--- a/ui/src/main/res/values-ar/string.xml
+++ b/ui/src/main/res/values-ar/string.xml
@@ -73,6 +73,8 @@
     <string name="dont_have_account">ليس لديك حساب؟</string>
     <string name="create_account">إنشاء حساب</string>
     <string name="incorrect_username_or_password">كلمة مرور او اسم المستخدم خاطئة</string>
+    <string name="account_disabled">تم تعطيل حسابك</string>
+    <string name="account_not_verified">لم يتم التحقق من عنوان بريدك الإلكتروني</string>
     <!-- -   -->
     <!-- - Mood Picker  -->
     <string name="mood_picker_title">محدد المزاج (احصل على فيلم)</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <string name="dont_have_account">Don’t have account?</string>
     <string name="create_account">Create account</string>
     <string name="incorrect_username_or_password">incorrect username or password</string>
+    <string name="account_disabled">Your Account has been Disabled</string>
+    <string name="account_not_verified">Your email address has not been verified</string>
     <!-- -   -->
     <!-- - Mood Picker  -->
     <string name="mood_picker_title">Mood Picker (Get a Movie)</string>

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginEffect.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginEffect.kt
@@ -2,6 +2,7 @@ package com.amsterdam.viewmodel.login
 
 sealed interface LoginEffect {
     data object NavigateToHome: LoginEffect
+    data object ShowCredentialsError: LoginEffect
     data object NavigateToRegister: LoginEffect
     data object NavigateToResetPassword: LoginEffect
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginUiState.kt
@@ -1,38 +1,30 @@
 package com.amsterdam.viewmodel.login
 
+import com.amsterdam.domain.exceptions.AccountDisabledException
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.exceptions.InvalidCredentialsException
+import com.amsterdam.domain.exceptions.VerificationRequiredException
 
 data class LoginUiState(
     val username: String = "",
     val password: String = "",
     val isLoginButtonLoading: Boolean = false,
     val isLoginButtonEnabled: Boolean = false,
-    val usernameError: UsernameErrorState? = null,
-    val passwordError: PasswordErrorState? = null,
+    val loginError: LoginErrorState? = null,
     val isPasswordShown: Boolean = false
 )
 
-sealed interface UsernameErrorState {
-    data object InvalidCredentials: UsernameErrorState
+sealed interface LoginErrorState {
+    data object InvalidCredentials: LoginErrorState
+    data object VerificationRequired: LoginErrorState
+    data object AccountDisabled: LoginErrorState
 
     companion object{
-        fun toUsernameErrorState(exception: AflamiException): UsernameErrorState?{
+        fun toLoginErrorState(exception: AflamiException): LoginErrorState?{
             return when (exception) {
                 is InvalidCredentialsException -> InvalidCredentials
-                else -> null
-            }
-        }
-    }
-}
-
-sealed interface PasswordErrorState {
-    data object InvalidCredentials: PasswordErrorState
-
-    companion object{
-        fun toPasswordErrorState(exception: AflamiException): PasswordErrorState?{
-            return when (exception) {
-                is InvalidCredentialsException -> InvalidCredentials
+                is VerificationRequiredException -> VerificationRequired
+                is AccountDisabledException -> AccountDisabled
                 else -> null
             }
         }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginUiState.kt
@@ -3,6 +3,7 @@ package com.amsterdam.viewmodel.login
 import com.amsterdam.domain.exceptions.AccountDisabledException
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.exceptions.InvalidCredentialsException
+import com.amsterdam.domain.exceptions.NetworkException
 import com.amsterdam.domain.exceptions.VerificationRequiredException
 
 data class LoginUiState(
@@ -18,14 +19,17 @@ sealed interface LoginErrorState {
     data object InvalidCredentials: LoginErrorState
     data object VerificationRequired: LoginErrorState
     data object AccountDisabled: LoginErrorState
+    data object NoInternet: LoginErrorState
+    data object UnknownError: LoginErrorState
 
     companion object{
-        fun toLoginErrorState(exception: AflamiException): LoginErrorState?{
+        fun toLoginErrorState(exception: AflamiException): LoginErrorState{
             return when (exception) {
                 is InvalidCredentialsException -> InvalidCredentials
                 is VerificationRequiredException -> VerificationRequired
                 is AccountDisabledException -> AccountDisabled
-                else -> null
+                is NetworkException -> NoInternet
+                else -> UnknownError
             }
         }
     }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginViewModel.kt
@@ -18,14 +18,14 @@ class LoginViewModel @Inject constructor(
 
     override fun onUserNameUpdated(username: String) {
         updateState {
-            it.copy(username = username, usernameError = null)
+            it.copy(username = username, loginError = null)
         }
         shouldEnableLoginButton()
     }
 
     override fun onPasswordUpdate(password: String) {
         updateState {
-            it.copy(password = password, passwordError = null)
+            it.copy(password = password, loginError = null)
         }
         shouldEnableLoginButton()
     }
@@ -95,10 +95,10 @@ class LoginViewModel @Inject constructor(
     private fun onLoginWithPasswordError(exception: AflamiException) {
         updateState {
             it.copy(
-                usernameError = UsernameErrorState.toUsernameErrorState(exception),
-                passwordError = PasswordErrorState.toPasswordErrorState(exception)
+                loginError = LoginErrorState.toLoginErrorState(exception),
             )
         }
+        sendNewEffect(LoginEffect.ShowCredentialsError)
     }
 
     private fun onLoginComplete() {

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/LoginViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/LoginViewModelTest.kt
@@ -2,7 +2,6 @@ package com.amsterdam.viewmodel
 
 import com.amsterdam.domain.useCase.authentication.LoginAsGuestUseCase
 import com.amsterdam.domain.useCase.authentication.LoginWithPasswordUseCase
-import com.amsterdam.viewmodel.home.HomeEffect
 import com.amsterdam.viewmodel.login.LoginEffect
 import com.amsterdam.viewmodel.login.LoginViewModel
 import com.amsterdam.viewmodel.utils.TestDispatcherProvider
@@ -79,7 +78,7 @@ class LoginViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.state.value
-            assertThat(state.usernameError)
+            assertThat(state.loginError)
         }
 
     @Test
@@ -103,7 +102,7 @@ class LoginViewModelTest {
             viewModel.onLoginClicked()
             advanceUntilIdle()
             val state = viewModel.state.value
-            assertThat(state.usernameError).isNull()
+            assertThat(state.loginError).isNull()
 
         }
 
@@ -233,7 +232,7 @@ class LoginViewModelTest {
             advanceUntilIdle()
 
             val statePassword = viewModel.state.value.passwordError
-            val stateUserName = viewModel.state.value.usernameError
+            val stateUserName = viewModel.state.value.loginError
             assertThat(statePassword).isNull()
             assertThat(stateUserName).isNull()
         }


### PR DESCRIPTION
# Pull Request Template

## Description

improved login ui fixes and handled the new error style like the figma design with a snackbar and added a snackbar host state that can be called globally from anywhere

---

## Changes Made
List the changes introduced in this pull request:

- Fixed top padding before the icon button
- Added a global snackbar host state
- Fixed padding between create account and continue as guest in landscape mode
- Handled more exceptions like account not verified or suspended or no internet exceptions

---

## Screenshots (if applicable)

<img width="475" height="864" alt="image" src="https://github.com/user-attachments/assets/1365b57b-9937-4c8d-a339-7e294f427288" />

<img width="475" height="864" alt="image" src="https://github.com/user-attachments/assets/31735ded-baf0-4c4f-ac5e-e2e94c56acfc" />

<img width="475" height="864" alt="image" src="https://github.com/user-attachments/assets/f0a76100-958d-43d8-a60c-91cb43e6c49d" />

<img width="625" height="303" alt="image" src="https://github.com/user-attachments/assets/0c9725ef-4018-4660-8142-aa599b0cf6c2" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.