### PR TITLE
Fix mode picker background and mode picker icons size

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/MoodPickerCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/MoodPickerCard.kt
@@ -60,6 +60,7 @@ fun MoodPickerCard(
                                 AppTheme.color.yellowAccent,
                             ),
                     ),
+                    alpha = 0.7f,
                 )
                 .border(1.dp, AppTheme.color.stroke, RoundedCornerShape(24.dp)),
     ) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/MoodPickerCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/MoodPickerCard.kt
@@ -172,15 +172,13 @@ private fun MoodIcon(
         painter = painterResource(iconRes),
         contentDescription = null,
         tint = tint,
-        modifier =
-            Modifier
-                .padding(4.dp)
-                .size(24.dp)
-                .clickable(
-                    interactionSource = MutableInteractionSource(),
-                    indication = null,
-                    onClick = onClick,
-                ),
+        modifier = Modifier
+            .size(32.dp)
+            .clickable(
+                interactionSource = MutableInteractionSource(),
+                indication = null,
+                onClick = onClick,
+            ),
     )
 }
 


### PR DESCRIPTION

## Description
Fix mode picker background and mode picker icons size

---

## Changes Made

- Fix mode picker background.
- Fix mode picker icons size

---

## Screenshots (if applicable)

Dark:
<img width="408" height="242" alt="image" src="https://github.com/user-attachments/assets/bcb4c1b6-e7c6-4dc9-8392-e262b61e6461" />

Light:
<img width="407" height="240" alt="image" src="https://github.com/user-attachments/assets/be1ff40f-4225-43e3-9df7-2f1c2b7fe79d" />

---

## Checklist

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

