### PR TITLE
Let the default language to be English if the language is not supported by the app

### DIFF
--- a/repository/src/main/java/com/amsterdam/repository/utils/DeviceLanguage.kt
+++ b/repository/src/main/java/com/amsterdam/repository/utils/DeviceLanguage.kt
@@ -3,5 +3,8 @@ package com.amsterdam.repository.utils
 import java.util.Locale
 
 fun getDeviceLanguage(): String {
-    return Locale.getDefault().language
+    return when (val language = Locale.getDefault().language.lowercase()) {
+        "en", "ar" -> language
+        else -> "en"
+    }
 }


### PR DESCRIPTION

## Description
Let the default language to be English if the language is not supported by the app.

---

## Changes Made
- Let the default language to be English if the language is not supported by the app

---

## Checklist

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
