### PR TITLE
Fix bottom text should be separated by circle does not square also padding problem

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/MovieMoodPickerDialogDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/MovieMoodPickerDialogDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -158,9 +159,13 @@ fun DialogContent(
 
                     Box(
                         modifier = Modifier
-                            .size(3.dp, 3.dp)
-                            .background(AppTheme.color.onPrimaryBody)
                             .padding(horizontal = 4.dp)
+                            .size(3.dp, 3.dp)
+
+                            .background(
+                                AppTheme.color.onPrimaryBody,
+                                shape = CircleShape
+                            )
                             .align(Alignment.CenterVertically)
                     )
 


### PR DESCRIPTION

## Description
Fix bottom text should be separated by circle does not square also padding problem
---

## Changes Made
- Fix bottom text should be separated by circle does not square also padding problem

---

## Screenshots (if applicable)

<img width="389" height="461" alt="image" src="https://github.com/user-attachments/assets/67938e61-9d32-46fb-b770-81dcfd640e2d" />

---

## Checklist

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
