### PR TITLE
fix: hide seasons with no episodes in series details

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -303,11 +303,15 @@ fun SeriesDetailsContent(
                     ?.item
                     ?.let { selectedExtra ->
                         when (selectedExtra) {
-                            SeriesExtras.SEASONS -> seasonsSection(
-                                seasons = state.seasons,
-                                interaction = interaction
-                            )
-
+                            SeriesExtras.SEASONS -> {
+                                val visibleSeasons = state.seasons.filter { it.episodeCount > 0 }
+                                if (visibleSeasons.isNotEmpty()) {
+                                    seasonsSection(
+                                        seasons = visibleSeasons,
+                                        interaction = interaction
+                                    )
+                                }
+                            }
                             SeriesExtras.MORE_LIKE_THIS -> MoreLikeSection(state.similarSeries)
                             SeriesExtras.REVIEWS -> ReviewSection(state.reviews)
                             SeriesExtras.GALLERY -> GallerySection(state.gallery)


### PR DESCRIPTION
# Pull Request Template


## Changes Made
- Filtered out seasons with episodeCount = 0
- Prevented rendering of empty seasons in UI



## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.