### PR TITLE
fix: Season title does not stick to the screen when scroll

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -190,9 +190,27 @@ fun SeriesDetailsContent(
         enter = fadeIn(tween(animationDuration)),
         exit = fadeOut(tween(animationDuration))
     ) {
-        Box(
+        Column(
             modifier = Modifier.fillMaxSize()
         ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(appBarColor)
+            ) {
+                DefaultAppBar(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .statusBarsPadding(),
+                    firstOption = painterResource(R.drawable.ic_outlined_star),
+                    lastOption = painterResource(R.drawable.ic_outlined_add_to_favourite),
+                    onNavigateBackClicked = interaction::onNavigateBack,
+                    onFirstOptionClicked = interaction::onRateClicked,
+                    onLastOptionClicked = interaction::onAddToListClicked
+                )
+                HorizontalDivider(color = dividerColor)
+            }
+
             LazyColumn(
                 state = listState,
                 modifier = Modifier
@@ -320,24 +338,6 @@ fun SeriesDetailsContent(
                             )
                         }
                     }
-            }
-
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(appBarColor)
-            ) {
-                DefaultAppBar(
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .statusBarsPadding(),
-                    firstOption = painterResource(R.drawable.ic_outlined_star),
-                    lastOption = painterResource(R.drawable.ic_outlined_add_to_favourite),
-                    onNavigateBackClicked = interaction::onNavigateBack,
-                    onFirstOptionClicked = interaction::onRateClicked,
-                    onLastOptionClicked = interaction::onAddToListClicked
-                )
-                HorizontalDivider(color = dividerColor)
             }
         }
     }


### PR DESCRIPTION
## Description
Fix season title

---

## Changes Made
List the changes introduced in this pull request:

- Change the screen parent layout to column
- Move the app bar to the first of the column

---

## Screenshots (if applicable)

[Screencast from 2025-07-30 17-01-07.webm](https://github.com/user-attachments/assets/a3fbc685-3f10-4cf2-9af7-c4894857fc24)


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---
