### PR TITLE
Fix/movie details images pager indicator

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/ImageErrorIndicator.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/ImageErrorIndicator.kt
@@ -25,7 +25,7 @@ fun ImageErrorIndicator(
         contentAlignment = Alignment.Center,
     ) {
         Image(
-            painter = painterResource(id = R.drawable.ic_cancel),
+            painter = painterResource(id = R.drawable.ic_film_roll),
             colorFilter = ColorFilter.tint(color = Color.Gray),
             contentDescription = null,
             modifier = modifier.size(size),

--- a/ui/src/main/java/com/amsterdam/ui/components/appBar/DefaultAppBar.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/appBar/DefaultAppBar.kt
@@ -62,10 +62,8 @@ fun DefaultAppBar(
                     IconButton(
                         painter = painter,
                         contentDescription = firstOptionContentDescription,
-                        containerColor = AppTheme.color.primaryVariant,
                         tint = AppTheme.color.body,
                         paddingValues = PaddingValues(8.dp),
-                        withBorder = true,
                         onClick = onFirstOptionClicked,
                     )
                 }
@@ -76,10 +74,8 @@ fun DefaultAppBar(
                     IconButton(
                         painter = painter,
                         contentDescription = lastOptionContentDescription,
-                        containerColor = AppTheme.color.primaryVariant,
                         tint = AppTheme.color.body,
                         paddingValues = PaddingValues(8.dp),
-                        withBorder = true,
                         onClick = onLastOptionClicked,
                     )
                 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -179,33 +180,14 @@ fun MovieContent(
                             .fillMaxWidth()
                             .height(263.dp),
                 ) {
-                    HorizontalPager(
-                        state = pagerState,
-                        modifier = Modifier.fillMaxSize()
-                    ) { page ->
-                        SafeImageView(
-                            model = state.moviePostersUrl[page],
-                            contentDescription = "",
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .animateContentSize(),
-                            onLoading = { ImageLoadingIndicator() },
-                            onError = { ImageErrorIndicator() },
+                    if(state.moviePostersUrl.isEmpty()) {
+                        ImageErrorIndicator()
+                    } else {
+                        PostersPager(
+                            pagerState = pagerState,
+                            postersUrl = state.moviePostersUrl
                         )
-
                     }
-
-                    PageIndicator(
-                        modifier = Modifier
-                            .zIndex(1f)
-                            .padding(4.dp)
-                            .background(AppTheme.color.primaryVariant, RoundedCornerShape(100.dp))
-                            .padding(vertical = 4.dp, horizontal = 2.dp)
-                            .align(Alignment.BottomEnd),
-                        numberOfPages = state.moviePostersUrl.size,
-                        selectedPage = pagerState.currentPage
-                    )
 
                     DefaultAppBar(
                         modifier =
@@ -316,6 +298,46 @@ fun MovieContent(
     }
 }
 
+@Composable
+private fun PostersPager(
+    pagerState: PagerState,
+    postersUrl: List<String>,
+) {
+    Box {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { page ->
+            SafeImageView(
+                model = postersUrl[page],
+                contentDescription = "",
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .animateContentSize(),
+                onLoading = { ImageLoadingIndicator() },
+                onError = { ImageErrorIndicator() },
+            )
+        }
+
+        if (postersUrl.size > 1) {
+            PageIndicator(
+                modifier = Modifier
+                    .zIndex(1f)
+                    .padding(4.dp)
+                    .background(
+                        AppTheme.color.primaryVariant,
+                        RoundedCornerShape(100.dp)
+                    )
+                    .padding(vertical = 4.dp, horizontal = 2.dp)
+                    .align(Alignment.BottomEnd),
+                numberOfPages = if (postersUrl.size >= 10) 10
+                else postersUrl.size,
+                selectedPage = pagerState.currentPage % 10
+            )
+        }
+    }
+}
 
 @Composable
 @ThemeAndLocalePreviews


### PR DESCRIPTION
# Pull Request Template

## Description
fix issues in poster pager in movie details 

---

## Changes Made
List the changes introduced in this pull request:

- fix indicator appearance if no posters found
- limit size of indicator to 10 
- change the place holder of image when its state is error

---

## Screenshots
https://github.com/user-attachments/assets/2f5010d3-595c-4ab9-af00-cdaa6777bc5e

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
