### PR TITLE
refactor: add padding top between description title and content

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/DescriptionSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/DescriptionSection.kt
@@ -1,9 +1,12 @@
 package com.amsterdam.ui.screens.movieDetails.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.R
 import com.amsterdam.designsystem.components.ExpandableText
 import com.amsterdam.designsystem.components.Text
@@ -17,6 +20,7 @@ fun DescriptionSection(modifier: Modifier = Modifier, description: String) {
             style = AppTheme.textStyle.headline.small,
             color = AppTheme.color.title,
         )
+        Spacer(modifier = Modifier.height(8.dp))
         ExpandableText(text = description)
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request improves the layout of the DescriptionSection in the movie details screen. It adds spacing between the "Description" title and the actual content to enhance readability and visual hierarchy.

---

## Changes Made

- Added Spacer with 8.dp height between the title and the expandable text in DescriptionSection.
- Improved overall UI alignment for better user experience.

---

## Screenshots 

<img width="266" height="579" alt="image" src="https://github.com/user-attachments/assets/b6d52837-5764-4716-ad8d-a4d3d05f85fe" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
