### PR TITLE
refactor: add padding top between ActorCard and ActorName and add pre…

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/ActorCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/ActorCard.kt
@@ -1,6 +1,8 @@
 package com.amsterdam.ui.screens.movieDetails.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,7 +14,9 @@ import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.components.ImageErrorIndicator
 import com.amsterdam.designsystem.components.ImageLoadingIndicator
 import com.amsterdam.designsystem.components.Text
+import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
+import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 import com.amsterdam.imageviewer.ui.SafeImageView
 import com.amsterdam.viewmodel.shared.movieAndSeriseDetails.ActorUiState
 
@@ -29,12 +33,26 @@ fun ActorCard(modifier: Modifier = Modifier, actor: ActorUiState) {
             onLoading = { ImageLoadingIndicator() },
             onError = { ImageErrorIndicator() },
         )
+        Spacer(modifier = Modifier.height(2.dp))
         Text(
             text = actor.name,
             style = AppTheme.textStyle.label.small,
             color = AppTheme.color.body,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@ThemeAndLocalePreviews
+@Composable
+private fun ActorCardPreview() {
+    AflamiTheme {
+        ActorCard(
+            actor = ActorUiState(
+                name = "Emma Watson",
+                photo = "https://example.com/emma_watson.jpg"
+            )
         )
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request improves the ActorCard UI component used in the movie details screen. It adds vertical spacing between the actor's image and name, and introduces a @Preview composable for development and testing purposes.

---

## Changes Made

- Added Spacer with 2.dp height between the actor's image and name.
- Implemented a @ThemeAndLocalePreviews composable function for ActorCard.
- Applied AflamiTheme to the preview for consistent theming.

---

## Screenshots 
<img width="556" height="238" alt="image" src="https://github.com/user-attachments/assets/89ad0f0e-7193-4d7c-85a5-fdfb87670893" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
