### PR TITLE
Fix recent search issues

### DIFF
--- a/localDatasource/src/main/java/com/amsterdam/localdatasource/roomDataBase/daos/RecentSearchDao.kt
+++ b/localDatasource/src/main/java/com/amsterdam/localdatasource/roomDataBase/daos/RecentSearchDao.kt
@@ -35,13 +35,13 @@ interface RecentSearchDao {
         keyword: String, searchType: SearchType, storedLanguage: String
     ): LocalSearchDto?
 
-    @Query("DELETE FROM ${DatabaseConstants.RECENT_SEARCH_TABLE} WHERE searchKeyword = :keyword and searchType = :searchType and storedLanguage = :storedLanguage")
+    @Query("DELETE FROM ${DatabaseConstants.RECENT_SEARCH_TABLE} WHERE searchKeyword = :keyword and searchType = :searchType")
     suspend fun deleteSearchByKeyword(
-        keyword: String, searchType: SearchType, storedLanguage: String
+        keyword: String, searchType: SearchType
     )
 
-    @Query("DELETE FROM ${DatabaseConstants.SEARCH_MOVIE_CROSS_REF_TABLE} WHERE searchKeyword = :keyword and searchType = :searchType and storedLanguage = :storedLanguage")
+    @Query("DELETE FROM ${DatabaseConstants.SEARCH_MOVIE_CROSS_REF_TABLE} WHERE searchKeyword = :keyword and searchType = :searchType")
     suspend fun deleteSearchMovieCrossRefByKeyword(
-        keyword: String, searchType: SearchType, storedLanguage: String
+        keyword: String, searchType: SearchType
     )
 }

--- a/localDatasource/src/main/java/com/amsterdam/localdatasource/roomDataBase/datasource/RecentSearchLocalDataSourceImpl.kt
+++ b/localDatasource/src/main/java/com/amsterdam/localdatasource/roomDataBase/datasource/RecentSearchLocalDataSourceImpl.kt
@@ -33,11 +33,10 @@ class RecentSearchLocalDataSourceImpl @Inject constructor(
 
     override suspend fun deleteRecentSearchByKeywordAndType(
         keyword: String,
-        searchType: SearchType,
-        storedLanguage: String
+        searchType: SearchType
     ) {
-        dao.deleteSearchByKeyword(keyword, searchType, storedLanguage)
-        dao.deleteSearchMovieCrossRefByKeyword(keyword, searchType, storedLanguage)
+        dao.deleteSearchByKeyword(keyword, searchType)
+        dao.deleteSearchMovieCrossRefByKeyword(keyword, searchType)
     }
 
     override suspend fun deleteExpiredRecentSearches(date: Instant) {

--- a/repository/src/main/java/com/amsterdam/repository/datasource/local/RecentSearchLocalSource.kt
+++ b/repository/src/main/java/com/amsterdam/repository/datasource/local/RecentSearchLocalSource.kt
@@ -19,8 +19,7 @@ interface RecentSearchLocalSource {
 
     suspend fun deleteRecentSearchByKeywordAndType(
         keyword: String,
-        searchType: SearchType,
-        storedLanguage: String
+        searchType: SearchType
     )
 
     suspend fun deleteExpiredRecentSearches(date: Instant)

--- a/repository/src/main/java/com/amsterdam/repository/repository/RecentSearchRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/RecentSearchRepositoryImpl.kt
@@ -39,8 +39,7 @@ class RecentSearchRepositoryImpl @Inject constructor(
     override suspend fun deleteRecentSearch(searchKeyword: String) {
         recentSearchLocalSource.deleteRecentSearchByKeywordAndType(
             searchKeyword,
-            SearchType.BY_KEYWORD,
-            getDeviceLanguage()
+            SearchType.BY_KEYWORD
         )
     }
 

--- a/repository/src/main/java/com/amsterdam/repository/utils/RecentSearchHandlerImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/utils/RecentSearchHandlerImpl.kt
@@ -40,11 +40,7 @@ class RecentSearchHandlerImpl @Inject constructor(
                 )
             )
         ) {
-            recentSearchLocalSource.deleteRecentSearchByKeywordAndType(
-                keyword,
-                searchType,
-                getDeviceLanguage()
-            )
+            recentSearchLocalSource.deleteRecentSearchByKeywordAndType(keyword, searchType)
         }
     }
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
@@ -222,16 +222,17 @@ class SearchViewModel @Inject constructor(
     }
 
     override fun onSaveSearchHistory() {
-        if (state.value.keyword.isBlank()) return
+        val keyword = state.value.keyword
+        if (keyword.isBlank()) return
         tryToExecute(
-            action = { recentSearchesUseCase.addRecentSearch(state.value.keyword) },
+            action = { recentSearchesUseCase.addRecentSearch(keyword) },
             onSuccess = { fetchRecentSearches() },
             onError = ::onFetchError,
         )
     }
 
     override fun onClickNavigateBack() {
-        if (state.value.keyword.isNotEmpty()) {
+        if (state.value.keyword.isNotBlank()) {
             onSaveSearchHistory()
             onClickClearSearch()
         } else {


### PR DESCRIPTION
## Description

When click back on search screen the keyword is now saved to recent search, also fixed deleting search entry by making the `deleteRecentSearch` deletes the same entry in any stored language to avoid duplicate the has been found

---

## Changes Made

- Fixed saving search entry after clicking back on search screen
- Fixed deleting search entry

---

## Screenshots (if applicable)

https://github.com/user-attachments/assets/2591d71a-d263-435f-a21b-cad677397ed8

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.