### PR TITLE
Add space between icon and text in GlobalSearchHub

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/globalSearchHub/GlobalSearchHub.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/globalSearchHub/GlobalSearchHub.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -62,6 +63,7 @@ fun GlobalSearchHub(
                 modifier = Modifier.height(40.dp),
                 contentScale = ContentScale.FillHeight,
             )
+            Spacer(Modifier.height(4.dp))
             Text(
                 text = stringResource(globalSearchHubUI.labelRes),
                 style = AppTheme.textStyle.title.small,


### PR DESCRIPTION
## Description
A 4dp spacer has been added between the icon and text in the GlobalSearchHub component to match the design in Figma 

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.