### PR TITLE
Prevent `StringIndexOutOfBoundsException` in ExpandableText

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/ExpandableText.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/ExpandableText.kt
@@ -57,11 +57,13 @@ fun ExpandableText(
 
     val annotatedText = buildAnnotatedString {
         if (isClickable && !isExpanded) {
-            val adjustedText = text.substring(0, lastCharacterIndex-4)
+            val safeEnd = (lastCharacterIndex - 4).coerceAtLeast(0)
+            val trimmedText = text.take(safeEnd)
                 .dropLast(showMoreText.length)
                 .dropLastWhile { it.isWhitespace() || it == '.' }
+
             withStyle(textSpanStyle) {
-                append(adjustedText)
+                append(trimmedText)
                 append(" ")
             }
 


### PR DESCRIPTION
## Description
Ensures that the `adjustedText` substring operation in the `ExpandableText` composable does not attempt to access an index out of bounds.

This is achieved by coercing the `lastCharacterIndex - 4` value to be at least 0 before creating the substring.

---
## Screenshots (if applicable)
<img width="1005" height="891" alt="Screenshot 2025-07-31 at 14 52 25" src="https://github.com/user-attachments/assets/c64ac0ed-8380-429b-8c67-1c83d3dbdadf" />


---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
