### PR TITLE
Fix wrong mapping to argument to Load search results

### DIFF
--- a/app/src/main/java/com/amsterdam/aflami/di/apiServiceModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/apiServiceModule.kt
@@ -1,12 +1,12 @@
 package com.amsterdam.aflami.di
 
+import com.amsterdam.domain.repository.AppPreferencesRepository
 import com.amsterdam.remotedatasource.api.AuthenticationApiService
 import com.amsterdam.remotedatasource.api.CategoryApiService
 import com.amsterdam.remotedatasource.api.CountryApiService
 import com.amsterdam.remotedatasource.api.MovieApiService
 import com.amsterdam.remotedatasource.api.TvShowsApiService
 import com.amsterdam.remotedatasource.client.RetrofitClient
-import com.amsterdam.repository.datasource.local.AppPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -29,7 +29,8 @@ object ServiceProvidesModule {
 
     @Provides
     @Singleton
-    fun provideRetrofitClient(json: Json, preferences: AppPreferences): RetrofitClient = RetrofitClient(json, preferences)
+    fun provideRetrofitClient(json: Json, preferences: AppPreferencesRepository): RetrofitClient =
+        RetrofitClient(json, preferences)
 
     @Provides
     @Singleton

--- a/remoteDatasource/src/main/java/com/amsterdam/remotedatasource/client/RetrofitClient.kt
+++ b/remoteDatasource/src/main/java/com/amsterdam/remotedatasource/client/RetrofitClient.kt
@@ -1,12 +1,12 @@
 package com.amsterdam.remotedatasource.client
 
+import com.amsterdam.domain.repository.AppPreferencesRepository
 import com.amsterdam.remotedatasource.BuildConfig
 import com.amsterdam.remotedatasource.api.AuthenticationApiService
 import com.amsterdam.remotedatasource.api.CategoryApiService
 import com.amsterdam.remotedatasource.api.CountryApiService
 import com.amsterdam.remotedatasource.api.MovieApiService
 import com.amsterdam.remotedatasource.api.TvShowsApiService
-import com.amsterdam.repository.datasource.local.AppPreferences
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 
 class RetrofitClient(
     private val json: Json,
-    private val preferences: AppPreferences
+    private val preferences: AppPreferencesRepository
 ) {
     private val TOKEN_HEADER_NAME = "Authorization"
     private val LANGUAGE_PARAM_NAME = "language"

--- a/repository/src/main/java/com/amsterdam/repository/repository/CategoryRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/CategoryRepositoryImpl.kt
@@ -64,7 +64,7 @@ class CategoryRepositoryImpl @Inject constructor(
         categoryLocalSource.upsertMovieCategories(
             movieCategoryRemoteLocalMapper.toLocalList(
                 movieCategories.genres,
-                listOf(preferences.getDeviceLanguage())
+                listOf(preferences.getDeviceLanguage().first())
             )
         )
     }
@@ -91,7 +91,7 @@ class CategoryRepositoryImpl @Inject constructor(
         categoryLocalSource.upsertTvShowCategories(
             tvShowCategoryRemoteLocalMapper.toLocalList(
                 tvShowCategories.genres,
-                listOf(preferences.getDeviceLanguage())
+                listOf(preferences.getDeviceLanguage().first())
             )
         )
     }

--- a/repository/src/main/java/com/amsterdam/repository/repository/CountryRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/CountryRepositoryImpl.kt
@@ -36,7 +36,12 @@ class CountryRepositoryImpl @Inject constructor(
 
     private suspend fun getCountriesFromLocal(): List<Country> {
         return try {
-            countryLocalMapper.toEntityList(localDataSource.getCountries(preferences.getDeviceLanguage().first()))
+
+            countryLocalMapper.toEntityList(
+                dtoList = localDataSource.getCountries(
+                    storedLanguage = preferences.getDeviceLanguage().first()
+                )
+            )
         } catch (_: Exception) {
             emptyList()
         }
@@ -44,9 +49,9 @@ class CountryRepositoryImpl @Inject constructor(
 
     private suspend fun saveCountries(remoteCountries: List<RemoteCountryDto>) {
         localDataSource.addCountries(
-            countryRemoteLocalMapper.toLocalList(
-                remoteCountries,
-                listOf(preferences.getDeviceLanguage())
+            countries = countryRemoteLocalMapper.toLocalList(
+                remoteList = remoteCountries,
+                args = listOf(preferences.getDeviceLanguage().first())
             )
         )
     }

--- a/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
@@ -173,11 +173,11 @@ class TvShowRepositoryImpl @Inject constructor(
         localTvDataSource.addTvShowWithCategories(
             tvShow = tvShowRemoteLocalMapper.toLocal(
                 remoteTvShow,
-                listOf(preferences.getDeviceLanguage())
+                listOf(preferences.getDeviceLanguage().first())
             ),
             categories = tvShowGenreIdsRemoteLocalMapper.toLocalList(
                 remoteTvShow.genreIds,
-                listOf(preferences.getDeviceLanguage())
+                listOf(preferences.getDeviceLanguage().first())
             ),
             storedLanguage = preferences.getDeviceLanguage().first()
         )

--- a/repository/src/main/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.amsterdam.repository.mapper.local.MovieWatchHistoryMapper
 import com.amsterdam.repository.mapper.local.TvShowLocalMapper
 import com.amsterdam.repository.mapper.local.TvShowWatchHistoryMapper
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -28,7 +29,7 @@ class WatchHistoryRepositoryImpl @Inject constructor(
         watchHistoryLocalDataSource.addMovieToWatchHistory(
             movieWatchHistoryMapper.toDto(
                 item,
-                listOf(preferences.getDeviceLanguage())
+                listOf(preferences.getDeviceLanguage().first())
             )
         )
     }
@@ -43,7 +44,7 @@ class WatchHistoryRepositoryImpl @Inject constructor(
         watchHistoryLocalDataSource.addTvShowToWatchHistory(
             tvShowWatchHistoryMapper.toDto(
                 item,
-                listOf(preferences.getDeviceLanguage())
+                listOf(preferences.getDeviceLanguage().first())
             )
         )
     }


### PR DESCRIPTION
## Description
The `getDeviceLanguage()` method in `Preferences` returns a list of languages. This PR updates the repositories to use only the first language in this list when interacting with local data sources and mappers.

Additionally, it refactors the `RetrofitClient` to use the `AppPreferencesRepository` interface instead of the concrete `AppPreferences` implementation.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
---