### PR TITLE
fix: update upcoming and similar movies to use backdrop images

### DIFF
--- a/repository/src/main/java/com/amsterdam/repository/mapper/remote/MovieDetailRemoteMapper.kt
+++ b/repository/src/main/java/com/amsterdam/repository/mapper/remote/MovieDetailRemoteMapper.kt
@@ -40,7 +40,7 @@ class MovieDetailRemoteMapper @Inject constructor(
             movie = movieRemoteMapper.toEntity(remoteMovieItemDto),
             reviews = reviewRemoteMapper.toEntityList(response.reviews.results),
             actors = castRemoteMapper.toEntityList(response.credits.cast),
-            similarMovies = movieRemoteMapper.toEntityList(response.similar.results),
+            similarMovies = movieRemoteMapper.toEntityList(response.similar.results,isPoster = false),
             movieGallery = galleryRemoteMapper.toEntity(response.images),
             moviePosters = posterRemoteMapper.toEntity(response.images),
         )

--- a/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
@@ -125,7 +125,7 @@ class MovieRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUpcomingMovies(): List<Movie> {
-        return movieRemoteMapper.toEntityList(movieRemoteDataSource.getUpcomingMovies().results)
+        return movieRemoteMapper.toEntityList(movieRemoteDataSource.getUpcomingMovies().results,isPoster = false)
     }
 
     override suspend fun getPopularMovies(): List<Movie> =


### PR DESCRIPTION
This commit modifies the `MovieRepositoryImpl` and `MovieDetailRemoteMapper` to ensure that upcoming movies and similar movies are displayed with backdrop images instead of poster images.

The `isPoster` parameter in the `toEntityList` method of `movieRemoteMapper` is now set to `false` for these specific cases.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

-
-
-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.