### PR TITLE
refactor: handle mood categories in mood picker

### DIFF
--- a/domain/src/main/java/com/amsterdam/domain/models/Mood.kt
+++ b/domain/src/main/java/com/amsterdam/domain/models/Mood.kt
@@ -3,12 +3,12 @@ package com.amsterdam.domain.models
 import com.amsterdam.entity.category.MovieGenre
 
 enum class Mood(val movieGenres: List<MovieGenre>) {
-    SAD(listOf(MovieGenre.DRAMA, MovieGenre.ROMANCE)),
-    THINKING(listOf(MovieGenre.SCIENCE_FICTION, MovieGenre.MYSTERY, MovieGenre.DOCUMENTARY)),
-    IN_LOVE(listOf(MovieGenre.ROMANCE, MovieGenre.COMEDY)),
-    ANGRY(listOf(MovieGenre.ACTION, MovieGenre.THRILLER)),
-    UN_HAPPY(listOf(MovieGenre.DRAMA, MovieGenre.WAR)),
-    CONFUSED(listOf(MovieGenre.DRAMA, MovieGenre.THRILLER));
+    SAD(listOf(MovieGenre.COMEDY)),
+    NEUTRAL(listOf(MovieGenre.DOCUMENTARY, MovieGenre.MYSTERY)),
+    ROMANTIC(listOf(MovieGenre.ROMANCE, MovieGenre.MUSIC)),
+    ANGRY(listOf(MovieGenre.COMEDY, MovieGenre.ANIMATION, MovieGenre.FAMILY)),
+    DEPRESSED(listOf(MovieGenre.DRAMA, MovieGenre.ANIMATION)),
+    SAD_DIZZY(listOf(MovieGenre.ADVENTURE, MovieGenre.FANTASY, MovieGenre.SCIENCE_FICTION));
 
     companion object {
         fun getMoodByName(moodName: String): Mood {

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
@@ -58,11 +58,11 @@ data class HomeUiState(
     data class MoodPickerUiState(
         val moods: List<Mood> = listOf(
             Mood.SAD,
-            Mood.THINKING,
-            Mood.IN_LOVE,
+            Mood.NEUTRAL,
+            Mood.ROMANTIC,
             Mood.ANGRY,
-            Mood.UN_HAPPY,
-            Mood.CONFUSED
+            Mood.DEPRESSED,
+            Mood.SAD_DIZZY
         ),
         val selectedMood: Mood? = null,
         val selectedMovie: MovieItemUiState = MovieItemUiState(),


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request updates the emotion-to-movie-genre mapping used for mood-based movie recommendations. The goal is to align the emotion categories and their associated genres with the new design and mapping as shown in the provided image.

---

## Changes Made

- Updated emotion categories from:
SAD, THINKING, IN_LOVE, ANGRY, UN_HAPPY, CONFUSED
to new categories:
SAD, NEUTRAL, ROMANTIC, ANGRY, DEPRESSED, SAD_DIZZY.
- Modified genre lists for each emotion to reflect new associations:

SAD → COMEDY

NEUTRAL → DOCUMENTARY, MYSTERY

ROMANTIC → ROMANCE, MUSICAL

ANGRY → COMEDY, ANIMATION, FAMILY

DEPRESSED → DRAMA, ANIMATION

SAD_DIZZY → ADVENTURE, FANTASY, SCIENCE_FICTION


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
