### PR TITLE
move drop shadow after size to ensure visibility in UI

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/MustLoginDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/MustLoginDialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
@@ -81,16 +82,17 @@ fun MustLoginDialog(
                 contentDescription = "",
                 modifier = Modifier
                     .size(80.dp)
-                    .clip(shape = RoundedCornerShape(24.dp))
-                    .border(
-                        width = 1.dp, AppTheme.color.stroke,
-                        shape = RoundedCornerShape(24.dp)
-                    )
                     .dropShadow(
                         blur = 12.dp,
                         shape = RoundedCornerShape(24.dp),
                         color = AppTheme.color.droppedShadowColor
                     )
+                    .clip(shape = RoundedCornerShape(24.dp))
+                    .border(
+                        width = 1.dp, AppTheme.color.stroke,
+                        shape = RoundedCornerShape(24.dp)
+                    )
+
             )
             Text(
                 modifier = Modifier.padding(vertical = 12.dp),
@@ -111,7 +113,7 @@ fun MustLoginDialog(
         }
     }
 }
-
+@Preview(showBackground = true)
 @Composable
 @ThemeAndLocalePreviews
 fun CustomDialogPreview() {


### PR DESCRIPTION
# Pull Request Template

## Description
move drop shadow after size to ensure visibility in UI
---


---

## Screenshots (if applicable)

<img width="2240" height="1328" alt="Aflami – MovieDetailsScreen kt  Aflami ui main  01_08_2025 04_05_18" src="https://github.com/user-attachments/assets/ccf8559b-dd7c-40b4-95d9-bd5501799647" />

---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.