### PR TITLE
Fix Search Placeholder Flicker

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/SearchScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/SearchScreen.kt
@@ -150,8 +150,7 @@ private fun SearchContent(
                     )
 
                     RecentSearchesSection(
-                        keyword = state.keyword,
-                        recentSearches = state.recentSearches,
+                        state = state,
                         onAllRecentSearchesCleared = interaction::onClickClearAllRecentSearches,
                         onRecentSearchClicked = interaction::onClickRecentSearch,
                         onRecentSearchCleared = interaction::onClickClearRecentSearch

--- a/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/RecentSearchesSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/search/keywordSearch/sections/RecentSearchesSection.kt
@@ -1,12 +1,17 @@
 package com.amsterdam.ui.screens.search.keywordSearch.sections
 
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -16,68 +21,89 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.R
+import com.amsterdam.designsystem.components.LoadingContainer
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.components.divider.HorizontalDivider
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.ui.components.RecentSearchItem
+import com.amsterdam.viewmodel.search.keywordSearch.SearchUiState
 
 @Composable
 internal fun RecentSearchesSection(
-    keyword: String,
-    recentSearches: List<String>,
+    state: SearchUiState,
     onAllRecentSearchesCleared: () -> Unit,
     onRecentSearchClicked: (String) -> Unit,
     onRecentSearchCleared: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(recentSearches.isNotEmpty() && keyword.isBlank()) {
-        Column(
-            modifier = modifier
-                .fillMaxWidth()
-                .background(color = AppTheme.color.surface)
-                .padding(top = 24.dp),
-        ) {
-            Row(
-                modifier = modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = stringResource(R.string.recent_searches),
-                    style = AppTheme.textStyle.title.medium,
-                    color = AppTheme.color.title,
-                    textAlign = TextAlign.Start,
-                )
+    AnimatedContent(
+        targetState = state,
+        transitionSpec = {
+            fadeIn(animationSpec = tween(1700)) togetherWith fadeOut(animationSpec = tween(1700))
+        },
+    ) {
+        when {
+            it.recentSearches.isNotEmpty() && it.keyword.isBlank() -> {
+                Column(
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .background(color = AppTheme.color.surface)
+                        .padding(top = 24.dp),
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = stringResource(R.string.recent_searches),
+                            style = AppTheme.textStyle.title.medium,
+                            color = AppTheme.color.title,
+                            textAlign = TextAlign.Start,
+                        )
 
-                Text(
-                    modifier = modifier.clickable(onClick = onAllRecentSearchesCleared),
-                    text = stringResource(R.string.clear_all),
-                    style = AppTheme.textStyle.label.medium,
-                    color = AppTheme.color.primary,
-                )
-            }
-            Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(top = 12.dp)
-            ) {
-                recentSearches.map { recentSearchItem ->
-                    RecentSearchItem(
-                        title = recentSearchItem,
-                        onItemClick = onRecentSearchClicked,
-                        onCancelClick = onRecentSearchCleared,
-                    )
-                    if (recentSearchItem != recentSearches.last()) HorizontalDivider()
+                        Text(
+                            modifier = Modifier.clickable(onClick = onAllRecentSearchesCleared),
+                            text = stringResource(R.string.clear_all),
+                            style = AppTheme.textStyle.label.medium,
+                            color = AppTheme.color.primary,
+                        )
+                    }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 12.dp)
+                    ) {
+                        it.recentSearches.map { recentSearchItem ->
+                            RecentSearchItem(
+                                title = recentSearchItem,
+                                onItemClick = onRecentSearchClicked,
+                                onCancelClick = onRecentSearchCleared,
+                            )
+                            if (recentSearchItem != it.recentSearches.last()) HorizontalDivider()
+                        }
+                    }
                 }
             }
-        }
-    }
 
-    AnimatedVisibility(keyword.isEmpty() && recentSearches.isEmpty()) {
-        val topPadding = if (LocalConfiguration.current.orientation == ORIENTATION_LANDSCAPE) {
-            12.dp
-        } else {
-            72.dp
+            it.keyword.isEmpty() && it.recentSearches.isEmpty() && it.isLoading == false -> {
+                val topPadding =
+                    if (LocalConfiguration.current.orientation == ORIENTATION_LANDSCAPE) {
+                        12.dp
+                    } else {
+                        72.dp
+                    }
+                ExploreMoviesAndShows(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = topPadding, bottom = 12.dp)
+                )
+            }
+
+            it.isLoading -> {
+                LoadingContainer(modifier = modifier
+                    .fillMaxSize()
+                    .padding(top = 48.dp))
+            }
         }
-        ExploreMoviesAndShows(Modifier.fillMaxWidth().padding(top = topPadding, bottom = 12.dp))
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/keywordSearch/SearchViewModel.kt
@@ -59,7 +59,8 @@ class SearchViewModel @Inject constructor(
         observeSearchKeywordChanges()
     }
 
-    private fun fetchRecentSearches() {
+    private fun fetchRecentSearches(startLoading: Boolean = true) {
+        startLoading(startLoading)
         tryToExecute(
             action = { recentSearchesUseCase.getRecentSearches() },
             onSuccess = ::onLoadRecentSearchesSuccess,
@@ -68,7 +69,7 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun onLoadRecentSearchesSuccess(recentSearches: List<String>) {
-        updateState { it.copy(recentSearches = recentSearches, errorUiState = null) }
+        updateState { it.copy(recentSearches = recentSearches, errorUiState = null, isLoading = false) }
     }
 
     private fun observeSearchKeywordChanges() {
@@ -214,7 +215,7 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun onFetchError(exception: AflamiException) {
-        updateState { it.copy(errorUiState = SearchErrorState.toSearchErrorState(exception)) }
+        updateState { it.copy(errorUiState = SearchErrorState.toSearchErrorState(exception), isLoading = false) }
     }
 
     private fun resetFilterState() {
@@ -226,7 +227,7 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    private fun startLoading() = updateState { it.copy(isLoading = true) }
+    private fun startLoading(start: Boolean = true) = updateState { it.copy(isLoading = start) }
 
     override fun onChangeSearchKeyword(keyword: String) {
         if (keyword.trim() != state.value.keyword.trim()) {
@@ -278,10 +279,9 @@ class SearchViewModel @Inject constructor(
     override fun onClickRecentSearch(keyword: String) = onChangeSearchKeyword(keyword)
 
     override fun onClickClearRecentSearch(keyword: String) {
-        startLoading()
         tryToExecute(
             action = { recentSearchesUseCase.deleteRecentSearch(searchKeyword = keyword) },
-            onSuccess = { fetchRecentSearches() },
+            onSuccess = { fetchRecentSearches(startLoading = false)},
             onError = ::onFetchError,
         )
     }
@@ -296,7 +296,7 @@ class SearchViewModel @Inject constructor(
     }
 
     private fun onClearAllRecentSearchesSuccess(unit: Unit) {
-        updateState { it.copy(recentSearches = emptyList()) }
+        updateState { it.copy(recentSearches = emptyList(), isLoading = false) }
     }
 
     override fun onClickClearSearch() {


### PR DESCRIPTION
# Pull Request Template

## Description

Refactor the RecentSearchesSection in the search screen to enhance user experience with animations and improved state handling.
This update introduces AnimatedContent for smoother UI transitions and improves the way loading states are managed during recent searches fetches and clear operations.
---

## Changes Made
List the changes introduced in this pull request:

- Refactored RecentSearchesSection to use AnimatedContent for smoother state transitions.
- Added a loading indicator tied to the isLoading flag in SearchUiState.
- Updated fetchRecentSearches in SearchViewModel to accept an optional startLoading parameter.
- Modified onClickClearRecentSearch to call fetchRecentSearches(startLoading = false) to prevent unnecessary loading display.
- Ensured loading state is properly reset in onClearAllRecentSearchesSuccess and onFetchError.

---

## Screenshots (if applicable)

https://github.com/user-attachments/assets/f4d6b4bd-d921-465b-bc01-5656c4c0c41b


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.