### PR TITLE
Fix Several Crashes in Offline Mode

### DIFF
--- a/repository/src/main/java/com/amsterdam/repository/mapper/remoteToLocal/MovieRemoteDetailsLocalMapper.kt
+++ b/repository/src/main/java/com/amsterdam/repository/mapper/remoteToLocal/MovieRemoteDetailsLocalMapper.kt
@@ -1,0 +1,26 @@
+package com.amsterdam.repository.mapper.remoteToLocal
+
+import com.amsterdam.repository.dto.local.LocalMovieDto
+import com.amsterdam.repository.dto.remote.RemoteMovieDetailsResponse
+import com.amsterdam.repository.mapper.shared.RemoteToLocalMapper
+import com.amsterdam.repository.utils.toSafeLocalDate
+import javax.inject.Inject
+
+class MovieRemoteDetailsLocalMapper @Inject constructor() :
+    RemoteToLocalMapper<RemoteMovieDetailsResponse, LocalMovieDto> {
+    override fun toLocal(remote: RemoteMovieDetailsResponse, args: List<Any>): LocalMovieDto {
+        return LocalMovieDto(
+            movieId = remote.id,
+            storedLanguage = args.first().toString(),
+            name = remote.title,
+            description = remote.overview,
+            poster = remote.posterPath.orEmpty(),
+            releaseDate = remote.releaseDate.toSafeLocalDate(),
+            rating = remote.voteAverage.toFloat(),
+            popularity = remote.popularity,
+            movieLength = remote.runtime,
+            hasVideo = remote.video,
+            originCountry = remote.originCountry.firstOrNull() ?: "",
+        )
+    }
+}

--- a/repository/src/main/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImpl.kt
@@ -15,8 +15,7 @@ import com.amsterdam.repository.dto.remote.RemoteMovieDetailsResponse
 import com.amsterdam.repository.dto.remote.TvShowDetailsRemoteResponse
 import com.amsterdam.repository.mapper.local.MovieWatchHistoryLocalMapper
 import com.amsterdam.repository.mapper.local.TvWatchHistoryLocalMapper
-import com.amsterdam.repository.mapper.remote.MovieDetailRemoteMapper
-import com.amsterdam.repository.mapper.remoteToLocal.MovieRemoteLocalMapper
+import com.amsterdam.repository.mapper.remoteToLocal.MovieRemoteDetailsLocalMapper
 import com.amsterdam.repository.mapper.remoteToLocal.TvShowRemoteDetailsLocalMapper
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -31,11 +30,10 @@ class WatchHistoryRepositoryImpl @Inject constructor(
     private val tvShowRemoteSource: TvShowsRemoteSource,
     private val preferences: AppPreferences,
     private val tvShowRemoteDetailsLocalMapper: TvShowRemoteDetailsLocalMapper,
+    private val movieRemoteDetailsLocalMapper: MovieRemoteDetailsLocalMapper,
     private val localTvDataSource: TvShowLocalSource,
     private val movieWatchHistoryLocalMapper: MovieWatchHistoryLocalMapper,
     private val tvWatchHistoryLocalMapper: TvWatchHistoryLocalMapper,
-    private val movieRemoteLocalMapper: MovieRemoteLocalMapper,
-    private val movieDetailRemoteMapper: MovieDetailRemoteMapper,
 ) : WatchHistoryRepository {
 
     override suspend fun addMovieToWatchHistory(movieId: Long) {
@@ -46,31 +44,38 @@ class WatchHistoryRepositoryImpl @Inject constructor(
         page: Int,
         pageSize: Int
     ): Flow<List<MovieWatchHistory>> = flow {
-        watchHistoryLocalDataSource.getMoviesWatchHistory(page, pageSize).collect {
-            emit(it.map { getMovieWatchHistory(it) })
+        runCatching {
+            watchHistoryLocalDataSource.getMoviesWatchHistory(page, pageSize).collect {
+                it.map { getMovieWatchHistory(it) }
+                    .also { emit(it) }
+            }
         }
     }
 
     private suspend fun getMovieWatchHistory(movieWatchHistoryDto: MovieWatchHistoryDto): MovieWatchHistory {
-        return movieLocalSource.getMovieById(movieWatchHistoryDto.movieId, preferences.getDeviceLanguage().first())
-            ?.let {
-                movieWatchHistoryLocalMapper.toEntity(it.copy(insertedDate = movieWatchHistoryDto.watchedDate))
-            }
-            ?: movieRemoteDataSource.getMovieDetailsById(movieWatchHistoryDto.movieId).run {
-                cacheWatchedMovie(this)
-                movieLocalSource.getMovieById(movieWatchHistoryDto.movieId, preferences.getDeviceLanguage().first())
-                    .let {
-                        movieWatchHistoryLocalMapper.toEntity(it!!.copy(insertedDate = movieWatchHistoryDto.watchedDate))
-                    }
-            }
+        val language = preferences.getDeviceLanguage().first()
+        return movieLocalSource.getMovieById(
+            movieWatchHistoryDto.movieId,
+            language
+        )?.let {
+            movieWatchHistoryLocalMapper.toEntity(
+                dto = it.copy(insertedDate = movieWatchHistoryDto.watchedDate)
+            )
+        } ?: movieWatchHistoryLocalMapper.toEntity(
+            dto = movieRemoteDetailsLocalMapper.toLocal(
+                remote = movieRemoteDataSource.getMovieDetailsById(movieWatchHistoryDto.movieId)
+                    .also { cacheWatchedMovie(it) },
+                args = listOf(language)
+            )
+        )
+
     }
 
     private suspend fun cacheWatchedMovie(remoteMovieDetailsResponse: RemoteMovieDetailsResponse) {
         movieLocalSource.insertMovie(
-            movieRemoteLocalMapper.toLocal(
-                remote = movieDetailRemoteMapper.mapMovieDetailsToMovieItemDto(
-                    remoteMovieDetailsResponse
-                ), args = listOf(preferences.getDeviceLanguage().first())
+            movie = movieRemoteDetailsLocalMapper.toLocal(
+                remote = remoteMovieDetailsResponse,
+                args = listOf(preferences.getDeviceLanguage().first())
             )
         )
     }
@@ -83,34 +88,39 @@ class WatchHistoryRepositoryImpl @Inject constructor(
         page: Int,
         pageSize: Int
     ): Flow<List<TvShowWatchHistory>> = flow {
-        watchHistoryLocalDataSource.getTvShowsWatchHistory(page, pageSize).collect {
-            emit(it.map { getTvShowWatchHistory(it) })
+        runCatching {
+            watchHistoryLocalDataSource.getTvShowsWatchHistory(page, pageSize).collect {
+                it.map { getTvShowWatchHistory(it) }
+                    .also { emit(it) }
+            }
         }
     }
 
 
     private suspend fun getTvShowWatchHistory(tvShowWatchHistoryDto: TvShowWatchHistoryDto): TvShowWatchHistory {
+        val language = preferences.getDeviceLanguage().first()
+
         return tvShowLocalDataSource.getTvShowById(
             tvShowWatchHistoryDto.tvShowId,
-            preferences.getDeviceLanguage().first()
+            language
         )?.let {
-            tvWatchHistoryLocalMapper.toEntity(it.copy(insertedDate = tvShowWatchHistoryDto.watchedDate))
-        }
-            ?: tvShowRemoteSource.getTvShowDetailsById(tvShowWatchHistoryDto.tvShowId).run {
-                cacheWatchedTvShow(this)
-                tvShowLocalDataSource.getTvShowById(
-                    tvShowWatchHistoryDto.tvShowId,
-                    preferences.getDeviceLanguage().first()
-                ).let {
-                    tvWatchHistoryLocalMapper.toEntity(it!!.copy(insertedDate = tvShowWatchHistoryDto.watchedDate))
-                }
-            }
+            tvWatchHistoryLocalMapper.toEntity(
+                dto = it.copy(insertedDate = tvShowWatchHistoryDto.watchedDate),
+            )
+        } ?: tvWatchHistoryLocalMapper.toEntity(
+            dto = tvShowRemoteDetailsLocalMapper.toLocal(
+                remote = tvShowRemoteSource.getTvShowDetailsById(tvShowWatchHistoryDto.tvShowId)
+                    .also { cacheWatchedTvShow(it) },
+                args = listOf(language)
+            )
+        )
     }
 
     private suspend fun cacheWatchedTvShow(remoteTvShowItemDto: TvShowDetailsRemoteResponse) {
         localTvDataSource.insertTvShow(
-            tvShowRemoteDetailsLocalMapper.toLocal(
-                remote = remoteTvShowItemDto, args = listOf(preferences.getDeviceLanguage().first())
+            tvShow = tvShowRemoteDetailsLocalMapper.toLocal(
+                remote = remoteTvShowItemDto,
+                args = listOf(preferences.getDeviceLanguage().first())
             )
         )
     }


### PR DESCRIPTION
## Description
This PR refactors the `WatchHistoryRepositoryImpl` to be able to catch exceptions inside the flow builder. It also remove the  not-null assertion operator to fix `NullPointerException` 

---
## Changes Made

- Introducing `MovieRemoteDetailsLocalMapper` for mapping `RemoteMovieDetailsResponse` to `LocalMovieDto`.
- Updating `WatchHistoryRepositoryImpl` to use `MovieRemoteDetailsLocalMapper` in `getMovieWatchHistory` and `cacheWatchedMovie` functions.
- Simplifying the logic for fetching and caching watched movies by directly using the new mapper.
- Adding `runCatching` blocks to `getMoviesWatchHistory` and `getTvShowsWatchHistory` for better error handling.
- Removing unused mappers: `MovieRemoteLocalMapper` and `MovieDetailRemoteMapper`.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.