### PR TITLE
refactor: adjust PopularSection Pager sizing

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/PopularMediaItemCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/PopularMediaItemCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,7 +45,7 @@ fun PopularMediaItemCard(
     modifier: Modifier = Modifier
 ) {
 
-    Column(modifier = modifier,horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(modifier = modifier.fillMaxSize(),horizontalAlignment = Alignment.CenterHorizontally) {
         Box {
             Box (
                 Modifier

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/sections/PopularSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/sections/PopularSection.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
@@ -188,11 +189,11 @@ private fun PopularMoviesPager(
     modifier: Modifier = Modifier,
     onClickMediaItem: (Long, MediaType) -> Unit
 ){
-    val itemWidth = 207.dp
-    val horizontalPadding = (screenWidth - itemWidth) / 2
+    val itemWidth = remember { 244.dp }
+    val horizontalPadding = remember { (screenWidth - itemWidth) / 2 }
     HorizontalPager(
         state = pagerState,
-        pageSpacing = 16.dp,
+        pageSize = PageSize.Fixed(itemWidth),
         contentPadding = PaddingValues(horizontal = horizontalPadding),
         modifier = modifier
     ) { page ->

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/sections/PopularSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/sections/PopularSection.kt
@@ -190,7 +190,7 @@ private fun PopularMoviesPager(
     onClickMediaItem: (Long, MediaType) -> Unit
 ){
     val itemWidth = remember { 244.dp }
-    val horizontalPadding = remember { (screenWidth - itemWidth) / 2 }
+    val horizontalPadding = remember { ((screenWidth - itemWidth) / 2).coerceAtLeast(0.dp) }
     HorizontalPager(
         state = pagerState,
         pageSize = PageSize.Fixed(itemWidth),


### PR DESCRIPTION
The HorizontalPager in PopularSection now uses `PageSize.Fixed` with a width of 244.dp. This ensures consistent item sizing.

The `itemWidth` and `horizontalPadding` are now remembered to avoid recalculations.

The PopularMediaItemCard now uses `fillMaxSize()` to ensure it correctly occupies the space allocated by the pager.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.
now its more similar to the design its not 100 % accurate but its more similar now the padding between the center item and 
the item beside it is 18.5 and this 18.5  and in the design is 16.dp
but now the center item width is 244.dp 
---

## Changes Made
List the changes introduced in this pull request:



---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.

https://github.com/user-attachments/assets/2b8355b2-9a57-41f3-9ef6-e3c22324a277

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.