### PR TITLE
fix: hide mood picker while loading to avoid visual clash with shimmer

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.ui.screens.home
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -173,10 +174,13 @@ private fun HomeScreenContent(
                 )
 
                 item {
-                    MoodPickerSection(
-                        state,
-                        interactionListener,
-                    )
+                    AnimatedVisibility(visible = !state.isLoading) {
+                        MoodPickerSection(
+                            state,
+                            interactionListener,
+                        )
+                    }
+
                 }
 
                 upcomingMoviesSection(


### PR DESCRIPTION
# Pull Request Template

## Description
fix: hide mood picker while loading to avoid visual clash with shimmer
---


## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.