### PR TITLE
Fix/details screens slider bug

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -174,7 +174,7 @@ fun MovieContent(
                     .filter { !it }
                     .collect {
                         delay(4000)
-                        val nextPage = (pagerState.currentPage + 1) % state.moviePostersUrl.size
+                        val nextPage = (pagerState.currentPage + 1) % 10
                         pagerState.animateScrollToPage(nextPage)
                     }
             }

--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -34,7 +34,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -83,6 +85,9 @@ import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.MovieExtras
 import com.amsterdam.viewmodel.movieDetails.MovieDetailsViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
 
 @Composable
 fun MovieDetailsScreen(viewModel: MovieDetailsViewModel = hiltViewModel()) {
@@ -159,10 +164,20 @@ fun MovieContent(
         }
     }
 
-    LaunchedEffect(true) {
-        while (true) {
-            delay(4000)
-            pagerState.animateScrollToPage(((pagerState.currentPage + 1) % 10))
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(pagerState.currentPage, state.moviePostersUrl.size) {
+        if (state.moviePostersUrl.size > 1) {
+            coroutineScope.launch {
+                snapshotFlow { pagerState.isScrollInProgress }
+                    .distinctUntilChanged()
+                    .filter { !it }
+                    .collect {
+                        delay(4000)
+                        val nextPage = (pagerState.currentPage + 1) % state.moviePostersUrl.size
+                        pagerState.animateScrollToPage(nextPage)
+                    }
+            }
         }
     }
 
@@ -382,27 +397,27 @@ fun MovieContent(
 
             }
         }
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(appBarColor)
-            ) {
-                DefaultAppBar(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .statusBarsPadding()
-                            .zIndex(10f)
-                            .onSizeChanged { headerHeight = it.height },
-                    firstOption = painterResource(R.drawable.ic_outlined_star),
-                    lastOption = painterResource(R.drawable.ic_outlined_add_to_favourite),
-                    onNavigateBackClicked = interactionListener::onClickBack,
-                    onFirstOptionClicked = interactionListener::onRateClicked,
-                    onLastOptionClicked = interactionListener::onAddToListClicked,
-                )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(appBarColor)
+        ) {
+            DefaultAppBar(
+                modifier =
+                    Modifier
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .statusBarsPadding()
+                        .zIndex(10f)
+                        .onSizeChanged { headerHeight = it.height },
+                firstOption = painterResource(R.drawable.ic_outlined_star),
+                lastOption = painterResource(R.drawable.ic_outlined_add_to_favourite),
+                onNavigateBackClicked = interactionListener::onClickBack,
+                onFirstOptionClicked = interactionListener::onRateClicked,
+                onLastOptionClicked = interactionListener::onAddToListClicked,
+            )
 
-                HorizontalDivider(color = dividerColor)
-            }
+            HorizontalDivider(color = dividerColor)
+        }
 
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -44,7 +44,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -99,6 +101,9 @@ import com.amsterdam.viewmodel.seriesDetails.SeriesDetailsViewModel
 import com.amsterdam.viewmodel.shared.Selectable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
 
 @Composable
 fun SeriesDetailsScreen(
@@ -174,10 +179,20 @@ fun SeriesDetailsContent(
     val pagerState = rememberPagerState { state.postersUrls.size }
     val deviceWidth = configuration.screenWidthDp
 
-    LaunchedEffect(true) {
-        while (true) {
-            delay(4000)
-            pagerState.animateScrollToPage(((pagerState.currentPage + 1) % 10))
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(pagerState.currentPage, state.postersUrls.size) {
+        if (state.postersUrls.size > 1) {
+            coroutineScope.launch {
+                snapshotFlow { pagerState.isScrollInProgress }
+                    .distinctUntilChanged()
+                    .filter { !it }
+                    .collect {
+                        delay(4000)
+                        val nextPage = (pagerState.currentPage + 1) % state.postersUrls.size
+                        pagerState.animateScrollToPage(nextPage)
+                    }
+            }
         }
     }
 

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -189,7 +189,7 @@ fun SeriesDetailsContent(
                     .filter { !it }
                     .collect {
                         delay(4000)
-                        val nextPage = (pagerState.currentPage + 1) % state.postersUrls.size
+                        val nextPage = (pagerState.currentPage + 1) % 10
                         pagerState.animateScrollToPage(nextPage)
                     }
             }


### PR DESCRIPTION
# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.
- bug fix of the pager auto slider doesn't work when holding the image for more than 4 seconds.
---

## Changes Made
List the changes introduced in this pull request:

- `New Implementation`: The updated code uses `snapshotFlow` to monitor the `isScrollInProgress` state of the pager. This ensures that the automatic scrolling will only happen when a user is not actively scrolling, preventing a conflict. A new `LaunchedEffect` block handles the automatic scrolling to the next page, with the page number now being calculated correctly using the size of the poster list, preventing out-of-bounds crashes.

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.