### PR TITLE
Update navigation to preserve backstack state on bottom navigation

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
+++ b/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
@@ -20,6 +20,7 @@ import com.amsterdam.designsystem.components.snackBar.SnackBarHost
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.ui.components.bottomNavigation.BottomNavigation
 import com.amsterdam.ui.navigation.NavGraph
+import com.amsterdam.ui.navigation.Route
 import com.amsterdam.viewmodel.application.ApplicationViewModel
 import kotlinx.coroutines.runBlocking
 
@@ -47,9 +48,12 @@ fun AflamiApp(
                         currentDestination = currentDestination,
                         onNavigate = {
                             navController.navigate(it) {
-                                popUpTo(it) {
-                                    inclusive = true
+                                popUpTo(Route.Tab.Home) {
+                                    saveState = true
                                 }
+
+                                launchSingleTop = true
+                                restoreState = true
                             }
                         },
                     )

--- a/ui/src/main/java/com/amsterdam/ui/screens/onBoarding/OnboardingScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/onBoarding/OnboardingScreen.kt
@@ -55,7 +55,7 @@ fun OnboardingScreen(
         onboardingViewModel.effect.collectLatest { effect ->
             when (effect) {
                 is OnboardingEffect.NavigateToLoginScreen -> {
-                    navController.navigate(Route.Tab.Home) {
+                    navController.navigate(Route.Login) {
                         popUpTo(Route.Onboarding) { inclusive = true }
                     }
                 }


### PR DESCRIPTION
## Description
This Pr fixes a bug where the app would navigate to the login screen after onboarding instead of the home screen. It also updates the bottom navigation to correctly handle popping the back stack.

---
## Changes Made
List the changes introduced in this pull request:

- `saveState` is now set to `true` to save the state of the popped destinations. 
- `launchSingleTop` and `restoreState` are also set to `true` to ensure proper backstack behavior and state restoration when navigating between bottom navigation tabs.
- navigation from onBoarding fixed to `Login` instead of `Home` route.

---
## Screenshots (if applicable)
https://github.com/user-attachments/assets/0b28ae26-695c-4b2a-b2f6-1141baffe0d3



---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.