### PR TITLE
fix: initial loading is not a shimmer

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
@@ -174,20 +174,19 @@ private fun HomeScreenContent(
                 )
 
                 item {
-                    AnimatedVisibility(visible = !state.isLoading) {
+                    AnimatedSectionVisibility(visible = !state.isLoading && state.error == null) {
                         MoodPickerSection(
-                            state,
-                            interactionListener,
+                            state = state,
+                            interactionListener = interactionListener
                         )
                     }
-
                 }
 
                 upcomingMoviesSection(
                     state = state.upcomingMoviesSectionUiState,
                     onChangeMovieGenre = interactionListener::onChangeUpcomingMovieGenre,
                     onMovieClicked = interactionListener::onClickUpcomingMovieCard,
-                    isVisible = state.error == null,
+                    isVisible = !state.isLoading&&state.error == null,
                     onVerticalOffsetChange = {
                         upcomingMoviesSectionYOffsetDp = it
                     },

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
@@ -16,7 +16,7 @@ data class HomeUiState(
     val topRatedMediaSectionUiState: TopRatedMediaSectionUiState = TopRatedMediaSectionUiState(),
     val continueWatchingMediaSectionUiState: ContinueWatchingMediaSectionUiState = ContinueWatchingMediaSectionUiState(),
     val moodPickerUiState: MoodPickerUiState = MoodPickerUiState(),
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val error: HomeError? = null
 ) {
     data class PopularMediaSectionUiState(

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
@@ -67,6 +67,7 @@ class HomeViewModel @Inject constructor(
             action = { getHomeScreenDataUseCase() },
             onSuccess = ::onGetHomeScreenDataSuccess,
             onError = ::onError,
+            onCompletion = ::onCompletion
         )
     }
 
@@ -288,5 +289,5 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun onCompletion() = updateState { it.copy() }
+    private fun onCompletion() = updateState { it.copy(isLoading = false) }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
Fix: Ensure shimmer stays until all home screen data is fully loaded

---

## Screenshots (if applicable)


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.