### PR TITLE
fix: add default language value to prevent DataStore crash

### DIFF
--- a/localDatasource/src/main/java/com/amsterdam/localdatasource/dataStore/AppPreferencesImpl.kt
+++ b/localDatasource/src/main/java/com/amsterdam/localdatasource/dataStore/AppPreferencesImpl.kt
@@ -28,7 +28,7 @@ class AppPreferencesImpl @Inject constructor(
 
     override fun getAppLanguage(): Flow<String> {
         return dataStore.data.map { preferences ->
-            preferences[CURRENT_LANGUAGE] ?: "en"
+            preferences[CURRENT_LANGUAGE] ?: ""
         }
     }
 

--- a/localDatasource/src/main/java/com/amsterdam/localdatasource/dataStore/AppPreferencesImpl.kt
+++ b/localDatasource/src/main/java/com/amsterdam/localdatasource/dataStore/AppPreferencesImpl.kt
@@ -28,7 +28,7 @@ class AppPreferencesImpl @Inject constructor(
 
     override fun getAppLanguage(): Flow<String> {
         return dataStore.data.map { preferences ->
-            preferences[CURRENT_LANGUAGE] ?: emptyFlow<String>().first()
+            preferences[CURRENT_LANGUAGE] ?: "en"
         }
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description
---
fixed app crash cause of language default value

## Changes Made
List the changes introduced in this pull request:

- added default value to app  language
-
-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments