### PR TITLE
refactor: update LoginViewModel state and enable login button and ref…

### DIFF
--- a/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/login/LoginViewModel.kt
@@ -18,16 +18,22 @@ class LoginViewModel @Inject constructor(
 
     override fun onUserNameUpdated(username: String) {
         updateState {
-            it.copy(username = username, loginError = null)
+            it.copy(
+                username = username,
+                loginError = null,
+                isLoginButtonEnabled = username.isNotBlank() && state.value.password.isNotBlank()
+            )
         }
-        shouldEnableLoginButton()
     }
 
     override fun onPasswordUpdate(password: String) {
         updateState {
-            it.copy(password = password, loginError = null)
+            it.copy(
+                password = password,
+                loginError = null,
+                isLoginButtonEnabled = password.isNotBlank() && state.value.username.isNotBlank()
+            )
         }
-        shouldEnableLoginButton()
     }
 
 
@@ -41,7 +47,7 @@ class LoginViewModel @Inject constructor(
         tryToExecute(
             action = ::onLoginStart,
             onSuccess = { onLoginSuccess() },
-            onError = ::onLoginWithPasswordError,
+            onError = ::onError,
             onCompletion = ::onLoginComplete
 
         )
@@ -51,7 +57,7 @@ class LoginViewModel @Inject constructor(
         tryToExecute(
             action = { onLoginAsGuestStart() },
             onSuccess = { onLoginSuccess() },
-            onError = {},
+            onError = ::onError,
             onCompletion = ::onLoginComplete
         )
     }
@@ -64,21 +70,7 @@ class LoginViewModel @Inject constructor(
         sendNewNavigationEffect(LoginEffect.NavigateToRegister)
     }
 
-    private fun shouldEnableLoginButton() {
-        if (state.value.username.isNotBlank() && state.value.password.isNotBlank()) {
-            updateState {
-                it.copy(
-                    isLoginButtonEnabled = true
-                )
-            }
-        } else {
-            updateState {
-                it.copy(isLoginButtonEnabled = false)
-            }
-        }
-    }
-
-    private suspend fun onLoginAsGuestStart(){
+    private suspend fun onLoginAsGuestStart() {
         updateState { it.copy(isLoginButtonLoading = true) }
         loginAsGuestUseCase()
     }
@@ -92,7 +84,7 @@ class LoginViewModel @Inject constructor(
         sendNewNavigationEffect(LoginEffect.NavigateToHome)
     }
 
-    private fun onLoginWithPasswordError(exception: AflamiException) {
+    private fun onError(exception: AflamiException) {
         updateState {
             it.copy(
                 loginError = LoginErrorState.toLoginErrorState(exception),

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/login/LoginViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/login/LoginViewModelTest.kt
@@ -1,21 +1,17 @@
-package com.amsterdam.viewmodel
+package com.amsterdam.viewmodel.login
 
+import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.useCase.authentication.LoginAsGuestUseCase
 import com.amsterdam.domain.useCase.authentication.LoginWithPasswordUseCase
-import com.amsterdam.viewmodel.login.LoginEffect
-import com.amsterdam.viewmodel.login.LoginViewModel
 import com.amsterdam.viewmodel.utils.TestDispatcherProvider
 import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -31,17 +27,11 @@ class LoginViewModelTest {
     @BeforeEach
     fun setUp() {
         loginAsGuestUseCase = mockk(relaxed = true)
-        Dispatchers.setMain(testDispatcherProvider.testDispatcher)
         viewModel = LoginViewModel(
             dispatcherProvider = testDispatcherProvider,
             loginWithPasswordUseCase = loginWithPasswordUseCase,
             loginAsGuestUseCase = loginAsGuestUseCase
         )
-    }
-
-    @AfterEach
-    fun tearDown() {
-        Dispatchers.resetMain()
     }
 
     @Test
@@ -78,7 +68,7 @@ class LoginViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.state.value
-            assertThat(state.loginError)
+            assertThat(state.loginError).isNull()
         }
 
     @Test
@@ -91,19 +81,18 @@ class LoginViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.state.value
-            assertThat(state.passwordError)
+            assertThat(state.loginError).isNull()
         }
 
     @Test
     fun `should set username error when login fail happens`() =
         testScope.runTest {
             viewModel.onUserNameUpdated("testuser")
-            testScheduler.advanceUntilIdle()
+            testScope.testScheduler.advanceUntilIdle()
             viewModel.onLoginClicked()
             advanceUntilIdle()
             val state = viewModel.state.value
             assertThat(state.loginError).isNull()
-
         }
 
 
@@ -111,12 +100,11 @@ class LoginViewModelTest {
     fun `should set password error when login fail happens`() =
         testScope.runTest {
             viewModel.onPasswordUpdate("testpassword")
-            testScheduler.advanceUntilIdle()
+            testScope.testScheduler.advanceUntilIdle()
             viewModel.onLoginClicked()
             advanceUntilIdle()
             val state = viewModel.state.value
-            assertThat(state.passwordError).isNull()
-
+            assertThat(state.loginError).isNull()
         }
 
     @Test
@@ -136,11 +124,21 @@ class LoginViewModelTest {
         }
 
     @Test
-    fun `login button should be enabled when both username and password are not blank`() =
+    fun `onUserNameUpdated should set login button to be enabled when both username and password are not blank`() =
         testScope.runTest {
-            viewModel.onUserNameUpdated("testuser")
             viewModel.onPasswordUpdate("testpassword")
-            testScheduler.advanceUntilIdle()
+            viewModel.onUserNameUpdated("testuser")
+            advanceUntilIdle()
+            val result = viewModel.state.value.isLoginButtonEnabled
+            assertThat(result).isTrue()
+        }
+
+    @Test
+    fun `onUserNameUpdated should set login button to be non enabled when both username is blank`() =
+        testScope.runTest {
+            viewModel.onUserNameUpdated("")
+            viewModel.onPasswordUpdate("testpassword")
+            advanceUntilIdle()
 
             val result = viewModel.state.value.isLoginButtonEnabled
             assertThat(result).isFalse()
@@ -151,7 +149,7 @@ class LoginViewModelTest {
         testScope.runTest {
             viewModel.onUserNameUpdated("")
             viewModel.onPasswordUpdate("testpassword")
-            testScheduler.advanceUntilIdle()
+            advanceUntilIdle()
 
             val result = viewModel.state.value.isLoginButtonLoading
             assertThat(result).isFalse()
@@ -162,7 +160,7 @@ class LoginViewModelTest {
         testScope.runTest {
             viewModel.onUserNameUpdated("testuser")
             viewModel.onPasswordUpdate("")
-            testScheduler.advanceUntilIdle()
+            advanceUntilIdle()
 
             val result = viewModel.state.value.isLoginButtonLoading
             assertThat(result).isFalse()
@@ -173,7 +171,7 @@ class LoginViewModelTest {
         testScope.runTest {
             viewModel.onUserNameUpdated("")
             viewModel.onPasswordUpdate("")
-            testScheduler.advanceUntilIdle()
+            advanceUntilIdle()
 
             val result = viewModel.state.value.isLoginButtonLoading
             assertThat(result).isFalse()
@@ -185,7 +183,7 @@ class LoginViewModelTest {
 
 
             viewModel.onUserNameUpdated("")
-            testScheduler.advanceUntilIdle()
+            advanceUntilIdle()
 
             val result = viewModel.state.value.isLoginButtonLoading
             assertThat(result).isFalse()
@@ -197,7 +195,7 @@ class LoginViewModelTest {
 
 
             viewModel.onPasswordUpdate("")
-            testScheduler.advanceUntilIdle()
+            testScope.testScheduler.advanceUntilIdle()
 
             val result = viewModel.state.value.isLoginButtonLoading
             assertThat(result).isFalse()
@@ -207,9 +205,9 @@ class LoginViewModelTest {
     @Test
     fun `onLoginClicked should set loading to false after operation regardless of outcome`() =
         testScope.runTest {
+            coEvery { loginWithPasswordUseCase(any(), any()) } throws AflamiException()
             viewModel.onLoginClicked()
-            testScheduler.advanceUntilIdle()
-
+            advanceUntilIdle()
             val result = viewModel.state.value.isLoginButtonLoading
             assertThat(result).isFalse()
         }
@@ -218,35 +216,78 @@ class LoginViewModelTest {
     fun `onLoginClicked should send NavigateToHome effect when login is successful`() =
         testScope.runTest {
             val effects = mutableListOf<LoginEffect>()
-            val job = launch { viewModel.effect.collect { it?.let { effects.add(it) } } }
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
             viewModel.onLoginClicked()
             advanceUntilIdle()
             job.cancel()
             assertThat(effects).contains(LoginEffect.NavigateToHome)
-        }
-
-    @Test
-    fun `onLoginClicked should set username and password errors when login fails`() =
-        testScope.runTest {
-            viewModel.onLoginClicked()
-            advanceUntilIdle()
-
-            val statePassword = viewModel.state.value.passwordError
-            val stateUserName = viewModel.state.value.loginError
-            assertThat(statePassword).isNull()
-            assertThat(stateUserName).isNull()
         }
 
     @Test
     fun `onContinueAsGuestClicked should send NavigateToHome effect after success`() =
         testScope.runTest {
             val effects = mutableListOf<LoginEffect>()
-            val job = launch { viewModel.effect.collect { it?.let { effects.add(it) } } }
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
             viewModel.onContinueAsGuestClicked()
             advanceUntilIdle()
             job.cancel()
             assertThat(effects).contains(LoginEffect.NavigateToHome)
+        }
 
+    @Test
+    fun `onForgotPasswordClicked should send NavigateToResetPassword effect`() =
+        testScope.runTest {
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            viewModel.onForgotPasswordClicked()
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.NavigateToResetPassword)
+        }
 
+    @Test
+    fun `onCreateAccountClicked should send NavigateToRegister effect`() =
+        testScope.runTest {
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            viewModel.onCreateAccountClicked()
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.NavigateToRegister)
+        }
+
+    @Test
+    fun `onLoginClicked should send ShowCredentialsError effect when login fails`() =
+        testScope.runTest {
+            coEvery { loginWithPasswordUseCase(any(), any()) } throws AflamiException()
+            viewModel.onLoginClicked()
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.ShowCredentialsError)
+        }
+
+    @Test
+    fun `onLoginClicked should set ShowCredentialsError effect when login fails`() =
+        testScope.runTest {
+            coEvery { loginWithPasswordUseCase(any(), any()) } throws AflamiException()
+            viewModel.onLoginClicked()
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.ShowCredentialsError)
+        }
+
+    @Test
+    fun `onContinueAsGuestClicked should update error state when login fails`() = testScope
+        .runTest {
+            coEvery { loginAsGuestUseCase() } throws AflamiException()
+
+            viewModel.onContinueAsGuestClicked()
+            advanceUntilIdle()
+            val result = viewModel.state.value.loginError
+            assertThat(result).isNotNull()
         }
 }

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/login/LoginViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/login/LoginViewModelTest.kt
@@ -1,0 +1,293 @@
+package com.amsterdam.viewmodel.login
+
+import com.amsterdam.domain.exceptions.AflamiException
+import com.amsterdam.domain.useCase.authentication.LoginAsGuestUseCase
+import com.amsterdam.domain.useCase.authentication.LoginWithPasswordUseCase
+import com.amsterdam.viewmodel.utils.TestDispatcherProvider
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginViewModelTest {
+    private lateinit var viewModel: LoginViewModel
+    private lateinit var loginAsGuestUseCase: LoginAsGuestUseCase
+
+    private val testDispatcherProvider = TestDispatcherProvider()
+    private var testScope = TestScope(testDispatcherProvider.testDispatcher)
+    private val loginWithPasswordUseCase: LoginWithPasswordUseCase = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        loginAsGuestUseCase = mockk(relaxed = true)
+        viewModel = LoginViewModel(
+            dispatcherProvider = testDispatcherProvider,
+            loginWithPasswordUseCase = loginWithPasswordUseCase,
+            loginAsGuestUseCase = loginAsGuestUseCase
+        )
+    }
+
+    @Test
+    fun `onUserNameUpdated should update username`() =
+        testScope.runTest {
+            val username = "testuser"
+
+            viewModel.onUserNameUpdated(username)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state.username).isEqualTo(username)
+        }
+
+    @Test
+    fun `onPasswordUpdate should update password`() =
+        testScope.runTest {
+            val password = "testpassword"
+
+            viewModel.onPasswordUpdate(password)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state.password).isEqualTo(password)
+        }
+
+    @Test
+    fun `onUserNameUpdated should clear username errors`() =
+        testScope.runTest {
+
+            val username = "testuser"
+
+            viewModel.onUserNameUpdated(username)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state.loginError).isNull()
+        }
+
+    @Test
+    fun `onPasswordUpdate should clear password errors`() =
+        testScope.runTest {
+
+            val password = "testpassword"
+
+            viewModel.onPasswordUpdate(password)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertThat(state.loginError).isNull()
+        }
+
+    @Test
+    fun `should set username error when login fail happens`() =
+        testScope.runTest {
+            viewModel.onUserNameUpdated("testuser")
+            testScope.testScheduler.advanceUntilIdle()
+            viewModel.onLoginClicked()
+            advanceUntilIdle()
+            val state = viewModel.state.value
+            assertThat(state.loginError).isNull()
+        }
+
+
+    @Test
+    fun `should set password error when login fail happens`() =
+        testScope.runTest {
+            viewModel.onPasswordUpdate("testpassword")
+            testScope.testScheduler.advanceUntilIdle()
+            viewModel.onLoginClicked()
+            advanceUntilIdle()
+            val state = viewModel.state.value
+            assertThat(state.loginError).isNull()
+        }
+
+    @Test
+    fun `onShowPasswordClicked should toggle password visibility when called`() =
+        testScope.runTest {
+            val initialState = viewModel.state.value.isPasswordShown
+
+            viewModel.onShowPasswordClicked()
+            advanceUntilIdle()
+
+            assertThat(viewModel.state.value.isPasswordShown).isEqualTo(!initialState)
+
+            viewModel.onShowPasswordClicked()
+            advanceUntilIdle()
+
+            assertThat(viewModel.state.value.isPasswordShown).isEqualTo(initialState)
+        }
+
+    @Test
+    fun `onUserNameUpdated should set login button to be enabled when both username and password are not blank`() =
+        testScope.runTest {
+            viewModel.onPasswordUpdate("testpassword")
+            viewModel.onUserNameUpdated("testuser")
+            advanceUntilIdle()
+            val result = viewModel.state.value.isLoginButtonEnabled
+            assertThat(result).isTrue()
+        }
+
+    @Test
+    fun `onUserNameUpdated should set login button to be non enabled when both username is blank`() =
+        testScope.runTest {
+            viewModel.onUserNameUpdated("")
+            viewModel.onPasswordUpdate("testpassword")
+            advanceUntilIdle()
+
+            val result = viewModel.state.value.isLoginButtonEnabled
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `login button should be disabled when username is blank`() =
+        testScope.runTest {
+            viewModel.onUserNameUpdated("")
+            viewModel.onPasswordUpdate("testpassword")
+            advanceUntilIdle()
+
+            val result = viewModel.state.value.isLoginButtonLoading
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `login button should be disabled when password is blank`() =
+        testScope.runTest {
+            viewModel.onUserNameUpdated("testuser")
+            viewModel.onPasswordUpdate("")
+            advanceUntilIdle()
+
+            val result = viewModel.state.value.isLoginButtonLoading
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `login button should be disabled when both username and password are blank`() =
+        testScope.runTest {
+            viewModel.onUserNameUpdated("")
+            viewModel.onPasswordUpdate("")
+            advanceUntilIdle()
+
+            val result = viewModel.state.value.isLoginButtonLoading
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `clearing username should disable login button when password is set`() =
+        testScope.runTest {
+
+
+            viewModel.onUserNameUpdated("")
+            advanceUntilIdle()
+
+            val result = viewModel.state.value.isLoginButtonLoading
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `clearing password should disable login button when username is set`() =
+        testScope.runTest {
+
+
+            viewModel.onPasswordUpdate("")
+            testScope.testScheduler.advanceUntilIdle()
+
+            val result = viewModel.state.value.isLoginButtonLoading
+            assertThat(result).isFalse()
+        }
+
+
+    @Test
+    fun `onLoginClicked should set loading to false after operation regardless of outcome`() =
+        testScope.runTest {
+            coEvery { loginWithPasswordUseCase(any(), any()) } throws AflamiException()
+            viewModel.onLoginClicked()
+            advanceUntilIdle()
+            val result = viewModel.state.value.isLoginButtonLoading
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `onLoginClicked should send NavigateToHome effect when login is successful`() =
+        testScope.runTest {
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            viewModel.onLoginClicked()
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.NavigateToHome)
+        }
+
+    @Test
+    fun `onContinueAsGuestClicked should send NavigateToHome effect after success`() =
+        testScope.runTest {
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            viewModel.onContinueAsGuestClicked()
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.NavigateToHome)
+        }
+
+    @Test
+    fun `onForgotPasswordClicked should send NavigateToResetPassword effect`() =
+        testScope.runTest {
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            viewModel.onForgotPasswordClicked()
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.NavigateToResetPassword)
+        }
+
+    @Test
+    fun `onCreateAccountClicked should send NavigateToRegister effect`() =
+        testScope.runTest {
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            viewModel.onCreateAccountClicked()
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.NavigateToRegister)
+        }
+
+    @Test
+    fun `onLoginClicked should send ShowCredentialsError effect when login fails`() =
+        testScope.runTest {
+            coEvery { loginWithPasswordUseCase(any(), any()) } throws AflamiException()
+            viewModel.onLoginClicked()
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.ShowCredentialsError)
+        }
+
+    @Test
+    fun `onLoginClicked should set ShowCredentialsError effect when login fails`() =
+        testScope.runTest {
+            coEvery { loginWithPasswordUseCase(any(), any()) } throws AflamiException()
+            viewModel.onLoginClicked()
+            val effects = mutableListOf<LoginEffect>()
+            val job = launch { viewModel.effect.collect { it.let { effects.add(it) } } }
+            advanceUntilIdle()
+            job.cancel()
+            assertThat(effects).contains(LoginEffect.ShowCredentialsError)
+        }
+
+    @Test
+    fun `onContinueAsGuestClicked should update error state when login fails`() = testScope
+        .runTest {
+            coEvery { loginAsGuestUseCase() } throws AflamiException()
+
+            viewModel.onContinueAsGuestClicked()
+            advanceUntilIdle()
+            val result = viewModel.state.value.loginError
+            assertThat(result).isNotNull()
+        }
+}


### PR DESCRIPTION
…actor its test and make the test coverage 100%

This commit refactors the `LoginViewModel` to:
- Update the `isLoginButtonEnabled` state directly within `onUserNameUpdated` and `onPasswordUpdate` based on the non-blank status of username and password.
- Remove the `shouldEnableLoginButton` function as its logic is now integrated into the state update.
- Consolidate error handling for login and guest login into a single `onError` function.

Additionally, this commit adds comprehensive unit tests for `LoginViewModel` covering various scenarios, including:
- Username and password updates
- Error clearing on input changes
- Login button enabled/disabled states
- Password visibility toggling
- Successful and failed login attempts (both regular and guest)
- Navigation effects for different actions (forgot password, create account)

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

- LoginViewModel
- LoginViewModelTest

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
<img width="1357" height="92" alt="image" src="https://github.com/user-attachments/assets/f8d63da9-fece-4ffa-a731-d2ae84f841a3" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.