### PR TITLE
test: add unit tests for RegisterViewModel with test coverage 100%

### DIFF
--- a/viewModel/src/test/java/com/amsterdam/viewmodel/register/RegisterViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/register/RegisterViewModelTest.kt
@@ -1,0 +1,68 @@
+package com.amsterdam.viewmodel.register
+
+import com.amsterdam.viewmodel.BuildConfig
+import com.amsterdam.viewmodel.utils.TestDispatcherProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RegisterViewModelTest {
+
+    private lateinit var viewModel: RegisterViewModel
+
+    private val testDispatcherProvider = TestDispatcherProvider()
+    private var testScope = TestScope(testDispatcherProvider.testDispatcher)
+
+    @BeforeEach
+    fun setUp() {
+        viewModel = RegisterViewModel(
+            dispatcherProvider = testDispatcherProvider
+        )
+    }
+    @Test
+    fun `init should set signUpUrl to BuildConfig value when called`() = testScope.runTest{
+        //Given && When
+        viewModel = RegisterViewModel(
+            dispatcherProvider = testDispatcherProvider
+        )
+        advanceUntilIdle()
+        //Then
+        val signUpUrl = viewModel.state.value.signUpUrl
+        assertThat(signUpUrl).isEqualTo(BuildConfig.MOVIE_SIGN_UP_URL)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `setLoading should update isLoginButtonLoading state`(loading: Boolean) = testScope.runTest {
+        // When
+        viewModel.setLoading(loading)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(viewModel.state.value.isLoading).isEqualTo(loading)
+    }
+
+    @Test
+    fun `onRegistrationComplete should send NavigateToSignIn effect when its call`() = testScope.runTest {
+        // Given
+        val effects = mutableListOf<RegisterEffect>()
+        val job = launch { viewModel.effect.collect { effects.add(it) } }
+
+        // When
+        viewModel.onRegistrationComplete()
+        advanceUntilIdle()
+        job.cancel()
+
+        // Then
+        assertThat(effects).contains(RegisterEffect.NavigateToSignIn)
+    }
+
+}


### PR DESCRIPTION
This commit introduces unit tests for the `RegisterViewModel`. The tests cover the following scenarios:
- Initialization: Verifies that the `signUpUrl` is correctly set from `BuildConfig`.
- Loading state: Checks if `setLoading` correctly updates the `isLoading` state.
- Navigation effect: Ensures that `onRegistrationComplete` sends the `NavigateToSignIn` effect.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

- add RegisterViewModelTest class

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
<img width="952" height="99" alt="image" src="https://github.com/user-attachments/assets/8498e190-9d2c-4867-bf6f-d9ed14b1629a" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.