### PR TITLE
test: add unit tests for ResetPasswordViewModel with test coverage 100%

### DIFF
--- a/viewModel/src/test/java/com/amsterdam/viewmodel/resetPassword/ResetPasswordViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/resetPassword/ResetPasswordViewModelTest.kt
@@ -1,0 +1,70 @@
+package com.amsterdam.viewmodel.resetPassword
+
+import com.amsterdam.viewmodel.BuildConfig
+import com.amsterdam.viewmodel.utils.TestDispatcherProvider
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.booleanArrayOf
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResetPasswordViewModelTest {
+
+
+    private lateinit var viewModel: ResetPasswordViewModel
+
+    private val testDispatcherProvider = TestDispatcherProvider()
+    private var testScope = TestScope(testDispatcherProvider.testDispatcher)
+
+    @BeforeEach
+    fun setUp() {
+        viewModel = ResetPasswordViewModel(
+            dispatcherProvider = testDispatcherProvider
+        )
+    }
+    @Test
+    fun `init should set signUpUrl to BuildConfig value when called`() = testScope.runTest{
+        //Given && When
+        viewModel = ResetPasswordViewModel(
+            dispatcherProvider = testDispatcherProvider
+        )
+        advanceUntilIdle()
+        //Then
+        val signUpUrl = viewModel.state.value.resetPasswordUrl
+        assertThat(signUpUrl).isEqualTo(BuildConfig.MOVIE_RESET_PASSWORD_URL)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `setLoading should update isLoginButtonLoading state`(loading: Boolean) = testScope.runTest {
+        // When
+        viewModel.setLoading(loading)
+        advanceUntilIdle()
+
+        // Then
+        assertThat(viewModel.state.value.isLoading).isEqualTo(loading)
+    }
+
+    @Test
+    fun `onResetPasswordComplete should send NavigateToSignIn effect when its call`() = testScope.runTest {
+        // Given
+        val effects = mutableListOf<ResetPasswordEffect>()
+        val job = launch { viewModel.effect.collect { effects.add(it) } }
+
+        // When
+        viewModel.onResetPasswordComplete()
+        advanceUntilIdle()
+        job.cancel()
+
+        // Then
+        assertThat(effects).contains(ResetPasswordEffect.NavigateToSignIn)
+    }
+
+}


### PR DESCRIPTION
This commit adds unit tests for the `ResetPasswordViewModel`. The tests cover the following scenarios:
- `init` should set the correct reset password URL from `BuildConfig`.
- `setLoading` should update the `isLoading` state.
- `onResetPasswordComplete` should send a `NavigateToSignIn` effect.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

- add ResetPasswordViewModelTest class

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
<img width="822" height="94" alt="image" src="https://github.com/user-attachments/assets/dacaae5b-2aaf-411a-876a-4e3864811635" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.