### PR TITLE
Fix: Remove redundant app bar in MovieDetailsScreen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -524,27 +524,8 @@ fun MovieContent(
                 onFirstOptionClicked = movieDetailsInteractionListener::onClickRate,
                 onLastOptionClicked = movieDetailsInteractionListener::onClickAddToList,
             )
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(appBarColor)
-            ) {
-                DefaultAppBar(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .statusBarsPadding()
-                            .zIndex(10f)
-                            .onSizeChanged { headerHeight = it.height },
-                    firstOption = painterResource(R.drawable.ic_outlined_star),
-                    lastOption = painterResource(R.drawable.ic_outlined_add_to_favourite),
-                    onNavigateBackClicked = movieDetailsInteractionListener::onClickBack,
-                    onFirstOptionClicked = movieDetailsInteractionListener::onClickRate,
-                    onLastOptionClicked = movieDetailsInteractionListener::onClickAddToList,
-                )
 
-                HorizontalDivider(color = dividerColor)
-            }
+            HorizontalDivider(color = dividerColor)
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
This PR simplifies the `MovieDetailsScreen` by removing redundant components

---

## Changes Made
List the changes introduced in this pull request:

- Removed an unnecessary `DefaultAppBar` and its wrapping `Column`.
- These elements were redundant, as the `MovieDetailsAppBar` already handles the app bar functionality.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.