### PR TITLE
Improve HomeViewModel and make it more testable

### DIFF
--- a/domain/src/main/java/com/amsterdam/domain/useCase/home/GetContinueWatchingScreenDataUseCase.kt
+++ b/domain/src/main/java/com/amsterdam/domain/useCase/home/GetContinueWatchingScreenDataUseCase.kt
@@ -3,21 +3,27 @@ package com.amsterdam.domain.useCase.home
 import com.amsterdam.entity.MovieWatchHistory
 import com.amsterdam.entity.TvShowWatchHistory
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 
 class GetContinueWatchingScreenDataUseCase(
     private val getContinueWatchingMoviesUseCase: GetContinueWatchingMoviesUseCase,
     private val getContinueWatchingTvShowsUseCase: GetContinueWatchingTvShowsUseCase,
 ) {
 
-    operator fun invoke(page: Int = 1, pageSize: Int = 20): ContinueWatchingScreenData {
-        return ContinueWatchingScreenData(
-            continueWatchingMovies = getContinueWatchingMoviesUseCase(page,pageSize/2),
-            continueWatchingTvShows = getContinueWatchingTvShowsUseCase(page,pageSize/2)
-        )
+    operator fun invoke(page: Int = 1, pageSize: Int = 20): Flow<ContinueWatchingScreenData> {
+        return combine(
+            getContinueWatchingMoviesUseCase(page, pageSize / 2),
+            getContinueWatchingTvShowsUseCase(page, pageSize / 2)
+        ) { moviesWitchHistory, tvShowsWitchHistory ->
+            ContinueWatchingScreenData(
+                continueWatchingMovies = moviesWitchHistory,
+                continueWatchingTvShows = tvShowsWitchHistory
+            )
+        }
     }
 
     data class ContinueWatchingScreenData(
-        val continueWatchingMovies: Flow<List<MovieWatchHistory>>,
-        val continueWatchingTvShows: Flow<List<TvShowWatchHistory>>
+        val continueWatchingMovies: List<MovieWatchHistory>,
+        val continueWatchingTvShows: List<TvShowWatchHistory>
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingViewModel.kt
@@ -49,9 +49,13 @@ class ContinueWatchingViewModel @Inject constructor(
                     config = PagingConfig(pageSize = 20),
                     pagingSourceFactory = {
                         PagingSource { page ->
-                            val continueWatchingScreenData = getContinueWatchingScreenDataUseCase(page = page, pageSize = 20)
-                            getLinearItemsList(continueWatchingScreenData.continueWatchingMovies.first(),
-                                continueWatchingScreenData.continueWatchingTvShows.first(),
+                            val continueWatchingScreenData = getContinueWatchingScreenDataUseCase(
+                                page = page,
+                                pageSize = 20
+                            ).first()
+                            getLinearItemsList(
+                                continueWatchingScreenData.continueWatchingMovies,
+                                continueWatchingScreenData.continueWatchingTvShows,
                                 continueWatchingUiStateMapper::continueWatchingMediaItemUiState,
                                 continueWatchingUiStateMapper::continueWatchingMediaItemUiState
                             ).sortedByDescending { it.dateAdded }
@@ -80,7 +84,8 @@ class ContinueWatchingViewModel @Inject constructor(
                     error = ContinueWatchingUiState.ContinueWatchingError.NetworkError
                 )
             }
-            else ->{}
+
+            else -> {}
         }
     }
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
@@ -2,7 +2,6 @@ package com.amsterdam.viewmodel.home
 
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.exceptions.AflamiException
-import com.amsterdam.domain.exceptions.NetworkException
 import com.amsterdam.domain.models.Mood
 import com.amsterdam.domain.useCase.home.GetContinueWatchingScreenDataUseCase
 import com.amsterdam.domain.useCase.home.GetContinueWatchingScreenDataUseCase.ContinueWatchingScreenData
@@ -21,11 +20,10 @@ import com.amsterdam.viewmodel.shared.uiStates.MovieItemUiState
 import com.amsterdam.viewmodel.shared.uiStates.media.MediaType
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
 import com.amsterdam.viewmodel.utils.getLinearItemsList
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -90,27 +88,22 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    fun onGetContinueWatchingScreenDataSuccess(continueWatchingData: ContinueWatchingScreenData) {
-        val movies = continueWatchingData.continueWatchingMovies
-        val tvShows = continueWatchingData.continueWatchingTvShows
-        viewModelScope.launch {
-            combine(movies, tvShows) { moviesWitchHistory, tvShowsWitchHistory ->
-                getLinearItemsList(
-                    moviesWitchHistory,
-                    tvShowsWitchHistory,
-                    continueWatchingUiStateMapper::continueWatchingMediaItemUiState,
-                    continueWatchingUiStateMapper::continueWatchingMediaItemUiState
-                )
-            }.collect {
-                updateState { currentState ->
-                    currentState.copy(
-                        continueWatchingMediaSectionUiState = currentState.continueWatchingMediaSectionUiState.copy(
-                            mediaItems = it.sortedByDescending { it.dateAdded }
-                        )
+    private fun onGetContinueWatchingScreenDataSuccess(continueWatchingData: Flow<ContinueWatchingScreenData>) {
+        continueWatchingData.onEach {
+            updateState { currentState ->
+                currentState.copy(
+                    continueWatchingMediaSectionUiState = currentState.continueWatchingMediaSectionUiState.copy(
+                        mediaItems = getLinearItemsList(
+                            it.continueWatchingMovies,
+                            it.continueWatchingTvShows,
+                            continueWatchingUiStateMapper::continueWatchingMediaItemUiState,
+                            continueWatchingUiStateMapper::continueWatchingMediaItemUiState
+                        ).sortedByDescending { it.dateAdded }
                     )
-                }
+                )
             }
-        }
+
+        }.launchIn(viewModelScope)
     }
 
 
@@ -164,6 +157,7 @@ class HomeViewModel @Inject constructor(
             if (popularMediaSectionUiState.mediaItems.isEmpty()) getHomeScreenData()
             if (topRatedMediaSectionUiState.mediaItems.isEmpty()) getHomeScreenData()
             if (upcomingMoviesSectionUiState.movies.isEmpty()) getUpcomingMoviesBySelectedGenre()
+            if (continueWatchingMediaSectionUiState.mediaItems.isEmpty()) getContinueWatchingData()
         }
     }
 
@@ -225,7 +219,6 @@ class HomeViewModel @Inject constructor(
     }
 
     override fun onClickGetAnotherMovie() {
-        if (state.value.moodPickerUiState.isLoadingMovies) return
         val currentMovieIndex = state.value.moodPickerUiState.movies.indexOf(
             state.value.moodPickerUiState.selectedMovie
         )
@@ -255,11 +248,7 @@ class HomeViewModel @Inject constructor(
             return
         }
         val moviesUiStates = homeUiStateMapper.moviesToMoviesItemsUiState(movies)
-        val selectedMovie = if (moviesUiStates.isNotEmpty()) {
-            moviesUiStates[(0..moviesUiStates.size - 1).random()]
-        } else {
-            MovieItemUiState()
-        }
+        val selectedMovie = moviesUiStates[(0..moviesUiStates.size - 1).random()]
         updateState {
             it.copy(
                 moodPickerUiState = it.moodPickerUiState
@@ -278,14 +267,11 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun onError(exception: AflamiException) {
-        when (exception) {
-            is NetworkException -> updateState {
-                it.copy(
-                    error = HomeError.NetworkError,
-                    moodPickerUiState = it.moodPickerUiState.copy(isLoadingMovies = false)
-                )
-            }
-            else -> {}
+        updateState {
+            it.copy(
+                error = HomeError.NetworkError,
+                moodPickerUiState = it.moodPickerUiState.copy(isLoadingMovies = false)
+            )
         }
     }
 


### PR DESCRIPTION
## Description
This PR refactors the `HomeViewModel` to enhance the handling of continue watching data:

---

## Changes Made
- **Streamlined Data Flow:** The `onGetContinueWatchingScreenDataSuccess` function now directly processes a `Flow<ContinueWatchingScreenData>` instead of manually combining separate movie and TV show flows. This simplifies the logic and improves data consistency.
- **Improved Initial Load:** The `onRetry` function now ensures that continue watching data is fetched if it's missing during the initial load or a retry attempt.
- **Optimized Mood Picker:** Removed an unnecessary check in `onClickGetAnotherMovie` that prevented fetching another movie if movies were already loading. The logic for selecting a random movie in `onGetMoviesByMoodSuccess` is also simplified, ensuring a movie is always selected if the list is not empty.
- **Simplified Error Handling:** The `onError` function now consistently sets the error state to `HomeError.NetworkError` for all `AflamiException` types.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---
## Additional Comments
Additionally, the `GetContinueWatchingScreenDataUseCase` now returns a `Flow<ContinueWatchingScreenData>` and uses `combine` to merge movie and TV show data, aligning with the ViewModel changes. The `ContinueWatchingViewModel` is updated to consume this new Flow-based data source.