### PR TITLE
Fix/enhance recently watched

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/continueWatching/ContinueWatchingScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/continueWatching/ContinueWatchingScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.amsterdam.designsystem.R
+import com.amsterdam.ui.R
 import com.amsterdam.designsystem.components.LoadingContainer
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.ui.application.LocalNavController
@@ -74,7 +74,7 @@ fun ContinueWatchingContent(
             .navigationBarsPadding()
     ) {
         DefaultAppBar(
-            title = stringResource(R.string.continue_watching),
+            title = stringResource(R.string.recently_watched),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingViewModel.kt
@@ -53,12 +53,16 @@ class ContinueWatchingViewModel @Inject constructor(
                                 page = page,
                                 pageSize = 20
                             ).first()
-                            getLinearItemsList(
+
+                            val mergedItems = getLinearItemsList(
                                 continueWatchingScreenData.continueWatchingMovies,
                                 continueWatchingScreenData.continueWatchingTvShows,
                                 continueWatchingUiStateMapper::continueWatchingMediaItemUiState,
                                 continueWatchingUiStateMapper::continueWatchingMediaItemUiState
-                            ).sortedByDescending { it.dateAdded }
+                            )
+                                .sortedByDescending { it.dateAdded }
+                                .take(10)
+                            mergedItems
                         }
                     }
                 ).flow.cachedIn(viewModelScope)


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request limits the number of items displayed in the Continue Watching screen to a maximum of 10. The purpose is to ensure the screen only shows the most recent 10 media items, sorted by dateAdded, and replaces older ones with new ones as needed. This avoids unnecessary paging and improves user experience by focusing on the most relevant content.

---

## Changes Made

- Modified the PagingSource inside ContinueWatchingViewModel to:
     Merge movies and TV shows.
     Sort them by dateAdded in descending order.
     Return only the top 10 items using take(10).

- Prevented paging from loading additional pages by capping the item list manually.

---

## Screenshots 

https://github.com/user-attachments/assets/a5cad2bd-3c8d-4a07-8614-03f36ba23bd2


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.