### PR TITLE
Fix: Bug31: App Briefly Loads in Dark Theme Before Switching to Saved Light Theme on Launch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ tensorflowLiteTaskVision = "0.4.3"
 firebaseMlCommon = "22.1.2"
 uiToolingPreviewAndroid = "1.8.3"
 uiTooling = "1.8.3"
+splashscreen = "1.0.1"
 
 [libraries]
 android-test-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "androidTestCore" }
@@ -113,6 +114,7 @@ sifr-shaded = { module = "com.github.mohamedd-hassan:Shaded", version.ref = "sha
 firebase-ml-common = { group = "com.google.firebase", name = "firebase-ml-common", version.ref = "firebaseMlCommon" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "uiTooling" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 
 
 [plugins]

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     uiGraphicsDependencies()
     hiltDependencies()
     kotlinxDateTime()
+    splashScreenDependency()
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
@@ -83,4 +84,8 @@ private fun DependencyHandlerScope.kotlinxDateTime() {
 
 private fun DependencyHandlerScope.coilDependencies() {
     implementation(libs.coil.compose)
+}
+
+private fun DependencyHandlerScope.splashScreenDependency() {
+    implementation(libs.androidx.core.splashscreen)
 }

--- a/ui/src/main/java/com/amsterdam/ui/application/MainActivity.kt
+++ b/ui/src/main/java/com/amsterdam/ui/application/MainActivity.kt
@@ -4,12 +4,22 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.amsterdam.viewmodel.application.ApplicationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val viewModel: ApplicationViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
+        splashScreen.setKeepOnScreenCondition { !viewModel.state.value.isThemeLoaded }
+
         super.onCreate(savedInstanceState)
+
         enableEdgeToEdge()
         setContent {
             AflamiApp()

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/application/ApplicationUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/application/ApplicationUiState.kt
@@ -7,6 +7,7 @@ data class ApplicationUiState(
     val startDestination: StartDestinations = StartDestinations.LOGIN,
     val restrictionLevel: RestrictionLevel = RestrictionLevel.STRICT,
     val isDarkTheme: Boolean = true,
+    val isThemeLoaded: Boolean = false,
     val language: ManageLocaleLanguageUseCase.Language = ManageLocaleLanguageUseCase.Language.ENGLISH
 ){
     enum class StartDestinations{

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/application/ApplicationViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/application/ApplicationViewModel.kt
@@ -1,6 +1,5 @@
 package com.amsterdam.viewmodel.application
 
-import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.useCase.authentication.GetsSessionType
 import com.amsterdam.domain.useCase.preferences.GetOnboardingStatusUseCase
@@ -57,9 +56,11 @@ class ApplicationViewModel @Inject constructor(
     private fun listenToAppSettings() {
         viewModelScope.launch(dispatcherProvider.IO) {
             manageAppThemeUseCase.getAppTheme().collect { isDarkTheme ->
+
                 updateState { state ->
                     state.copy(
-                        isDarkTheme = isDarkTheme
+                        isDarkTheme = isDarkTheme,
+                        isThemeLoaded = true
                     )
                 }
             }


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request introduces a splash screen that remains visible until the app's theme has been fully loaded.
It also manages the theme loading state to ensure a smoother user experience during app startup.
---

## Changes Made
List the changes introduced in this pull request:
- Added isThemeLoaded to ApplicationUiState to track theme loading status.
- Updated ApplicationViewModel to set isThemeLoaded to true after the theme is collected.
- Added androidx.core:core-splashscreen dependency.
- Implemented splash screen display logic in MainActivity to wait for theme loading.

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
before:
https://github.com/user-attachments/assets/c2857e89-4143-4315-8686-ddc7512e47a0

after:
https://github.com/user-attachments/assets/d6009e7c-01c8-42fe-aaf9-5e80e5fbcd67
---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.