### PR TITLE
Fix: Bug34: Shimmer Effect Briefly Flashes on Retry Button Click in My Rating Screen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/NoNetworkContainer.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/NoNetworkContainer.kt
@@ -27,6 +27,7 @@ fun NoNetworkContainer(
     imageRes: Painter = painterResource(R.drawable.placeholder_no_connection),
     title: String = stringResource(R.string.offline_message),
     description: String = stringResource(R.string.offline_description),
+    showRetryLoading: Boolean = false
 ) {
     Column(
         modifier = modifier.fillMaxWidth().padding(horizontal = 24.dp),
@@ -56,7 +57,7 @@ fun NoNetworkContainer(
             title = stringResource(R.string.retry),
             onClick = onClickRetry,
             isEnabled = true,
-            isLoading = false,
+            isLoading = showRetryLoading,
             isNegative = false,
             modifier = Modifier.padding(top = 16.dp),
         )

--- a/ui/src/main/java/com/amsterdam/ui/screens/myRating/MyRatingScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/myRating/MyRatingScreen.kt
@@ -89,8 +89,13 @@ fun MyRatingScreen(
                     is MyRatingUiEffect.NavigateBack -> navigateUp()
                     is MyRatingUiEffect.NavigateToMovieDetails -> navigate(MovieDetails(movieId = effect.movieId))
                     is MyRatingUiEffect.NavigateToSeriesDetails -> navigate(SeriesDetails(tvShowId = effect.tvShowId))
-                    MyRatingUiEffect.ShowDeleteRateSuccessSnackBar -> SnackBarManager.showSuccess(message = successRateDeletionMessage)
-                    MyRatingUiEffect.ShowDeleteRateErrorSnackBar -> SnackBarManager.showError(message = errorRateDeletionMessage)
+                    MyRatingUiEffect.ShowDeleteRateSuccessSnackBar -> SnackBarManager.showSuccess(
+                        message = successRateDeletionMessage
+                    )
+
+                    MyRatingUiEffect.ShowDeleteRateErrorSnackBar -> SnackBarManager.showError(
+                        message = errorRateDeletionMessage
+                    )
                 }
             }
         }
@@ -109,7 +114,8 @@ private fun MyRatingContent(
     var appBarHeight by remember { mutableIntStateOf(0) }
     var tabsHeight by remember { mutableIntStateOf(0) }
 
-    val availableHeight = calculateAvailableHeight(appBarHeightPx = appBarHeight, tabsHeightPx = tabsHeight)
+    val availableHeight =
+        calculateAvailableHeight(appBarHeightPx = appBarHeight, tabsHeightPx = tabsHeight)
 
     LazyVerticalGrid(
         modifier = Modifier
@@ -134,7 +140,9 @@ private fun MyRatingContent(
 
         stickyHeader {
             TabsLayout(
-                modifier = Modifier.fillMaxWidth().onSizeChanged { tabsHeight = it.height },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .onSizeChanged { tabsHeight = it.height },
                 tabs = listOf(stringResource(R.string.movies), stringResource(R.string.tv_shows)),
                 selectedIndex = state.selectedTabOption.index,
                 onSelectTab = { index -> interaction.onChangeTabOption(TabOption.entries[index]) },
@@ -145,7 +153,7 @@ private fun MyRatingContent(
         val isTvShowTabSelected = state.selectedTabOption.index == TabOption.TV_SHOWS.index
 
         when {
-            state.isLoading -> mediaCardsPlaceholder()
+            state.isLoading && !state.isRetryLoading -> mediaCardsPlaceholder()
 
             state.movies.isNotEmpty() && isMovieTabSelected -> {
                 items(state.movies, key = { it.id }) { movie ->
@@ -204,6 +212,8 @@ private fun MyRatingContent(
                     modifier = Modifier.height(availableHeight),
                     errorState = state.error ?: MyRatingErrorState.UnknownError,
                     interaction = interaction,
+                    showRetryLoading = state.isRetryLoading
+
                 )
             }
 
@@ -247,15 +257,18 @@ private fun calculateAvailableHeight(
 private fun LazyGridScope.getErrorContentByErrorUiState(
     errorState: MyRatingErrorState,
     interaction: MyRatingInteractionListener,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showRetryLoading: Boolean
 ) {
     return when (errorState) {
         MyRatingErrorState.NoInternetError -> item(span = { GridItemSpan(maxLineSpan) }) {
             NoNetworkContainer(
                 modifier = modifier,
-                onClickRetry = interaction::onClickRetryRequest
+                onClickRetry = interaction::onClickRetryRequest,
+                showRetryLoading = showRetryLoading
             )
         }
+
         else -> emptyRatingListPlaceholder(
             modifier = modifier,
             titleRes = R.string.error_rated_media_title,

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/myRating/MyRatingUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/myRating/MyRatingUiState.kt
@@ -11,6 +11,7 @@ data class MyRatingUiState(
     val movies: List<MovieItemUiState> = emptyList(),
     val tvShows: List<TvShowItemUiState> = emptyList(),
     val isLoading: Boolean = false,
+    val isRetryLoading: Boolean = false,
     val error: MyRatingErrorState? = null,
 )
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/myRating/MyRatingViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/myRating/MyRatingViewModel.kt
@@ -57,10 +57,10 @@ class MyRatingViewModel @Inject constructor(
     }
 
     private fun onGetRatedMediaError(exception: AflamiException) {
-        updateState { it.copy(error = MyRatingErrorState.mapToUiState(exception)) }
+        updateState { it.copy(error = MyRatingErrorState.mapToUiState(exception), isRetryLoading = false) }
     }
 
-    private fun onCompletion() = updateState { it.copy(isLoading = false) }
+    private fun onCompletion() = updateState { it.copy(isLoading = false, isRetryLoading = false) }
 
     override fun onClickNavigateBack() = sendNewNavigationEffect(MyRatingUiEffect.NavigateBack)
 
@@ -117,7 +117,7 @@ class MyRatingViewModel @Inject constructor(
 
 
     override fun onClickRetryRequest() {
-        updateState { it.copy(error = null) }
+        updateState { it.copy(isRetryLoading = true) }
         refreshRatedContent()
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request fixes an issue where the retry button on the MyRatingScreen did not properly reflect a loading state when a network error occurred.
---

## Changes Made
List the changes introduced in this pull request:

- Added isRetryLoading to MyRatingUiState to track the loading state of the retry button.

- - Updated MyRatingViewModel:
- Sets isRetryLoading = true when onClickRetryRequest() is called.
- Resets isRetryLoading = false when the retry request completes or fails.

- Passed isRetryLoading to NoNetworkContainer to display a loading indicator on the retry button.
- Hid the main loading placeholder while retry loading is active.
---

## Screenshots (if applicable)
Before:

https://github.com/user-attachments/assets/35450e92-b391-4413-a537-16e50caa8e0a

After:

https://github.com/user-attachments/assets/0764f224-db4b-406c-81b3-56bf0c81fa60



---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.
