### PR TITLE
Fix: Add movie to list loading

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/AddToListDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/AddToListDialog.kt
@@ -41,6 +41,7 @@ fun AddToListDialog(
     userLists: List<UserListUiState>,
     modifier: Modifier = Modifier,
     selectedList: UserListUiState? = null,
+    isAddMovieToListLoading: Boolean = false,
     onSelectedListChange: (UserListUiState) -> Unit = {},
     onAddToSelectedList: (Long) -> Unit = {},
     onCreateNewList: () -> Unit = {},
@@ -76,9 +77,10 @@ fun AddToListDialog(
             }
             ActionButtonsSection(
                 selectedList = selectedList,
+                isAddMovieToListLoading = isAddMovieToListLoading,
                 onAddToSelectedList = onAddToSelectedList,
                 onCreateNewList = onCreateNewList,
-                modifier = Modifier.padding(bottom = 12.dp)
+                modifier = Modifier.padding(bottom = 12.dp),
             )
         }
     }
@@ -147,6 +149,7 @@ private fun SelectionListItem(
 @Composable
 private fun ActionButtonsSection(
     selectedList: UserListUiState?,
+    isAddMovieToListLoading: Boolean,
     onAddToSelectedList: (Long) -> Unit,
     onCreateNewList: () -> Unit,
     modifier: Modifier = Modifier,
@@ -159,7 +162,7 @@ private fun ActionButtonsSection(
             title = stringResource(R.string.add),
             onClick = { onAddToSelectedList(selectedList?.id!!) },
             isEnabled = selectedList != null,
-            isLoading = false,
+            isLoading = isAddMovieToListLoading,
             isNegative = false,
             modifier = Modifier,
         )

--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -311,6 +311,7 @@ fun MovieContent(
             AddToListDialog(
                 userLists = state.userLists,
                 selectedList = state.selectedList,
+                isAddMovieToListLoading = state.isAddMovieToListLoading,
                 onSelectedListChange = movieDetailsInteractionListener::onSelectedListChange,
                 onAddToSelectedList = { listId ->
                     movieDetailsInteractionListener.onSaveMovieToList(

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiState.kt
@@ -38,6 +38,7 @@ data class MovieDetailsUiState(
     val userLists: List<UserListUiState> = emptyList(),
     val listName: String = "",
     val isCreateListLoading: Boolean = false,
+    val isAddMovieToListLoading: Boolean = false,
     val selectedList: UserListUiState? = null,
 ) {
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsViewModel.kt
@@ -125,6 +125,7 @@ class MovieDetailsViewModel @Inject constructor(
     override fun onClickCancel() {
         updateState {
             it.copy(
+                isAddMovieToListLoading = false,
                 isLoginDialogVisible = false,
                 isAddToListDialogVisible = false,
                 isCreateNewListDialogVisible = false,
@@ -175,6 +176,7 @@ class MovieDetailsViewModel @Inject constructor(
         movieId: Int,
         listId: Long,
     ) {
+        updateState { it.copy(isAddMovieToListLoading = true) }
         tryToExecute(
             action = { addMovieToListUseCase(movieId = movieId, listId = listId) },
             onSuccess = {


### PR DESCRIPTION
## Description
This PR enhances the user experience by introducing a loading indicator on the **'Add' button** within the `AddToListDialog`.

---

## Changes Made
List the changes introduced in this pull request:

### 🎨 UI Enhancements
- The **'Add' button** now shows a **loading spinner** while a movie is being added to the selected list.
- This provides users with immediate visual feedback that their action is being processed.

### 🧠 State Management
- Added `isAddMovieToListLoading` to `MovieDetailsUiState`.
- State is controlled within `MovieDetailsViewModel`:
  - Set to `true` when the 'Add' operation begins.
  - Reset to `false` on completion or dialog dismissal.

### 💡 Affected Composables
- `AddToListDialog`
- `ActionButtonsSection`

---

## Screenshots (if applicable)

[Screencast from 2025-08-07 15-46-27.webm](https://github.com/user-attachments/assets/161c4200-4e2f-4d92-b6ed-1657825685b0)

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---