### PR TITLE
Fix: Clear create new list dialog state after dismiss

### DIFF
--- a/viewModel/src/main/java/com/amsterdam/viewmodel/lists/UserListsViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/lists/UserListsViewModel.kt
@@ -145,7 +145,7 @@ class UserListsViewModel @Inject constructor(
     }
 
     override fun onDismiss() {
-        updateState { it.copy(isCreateNewListDialogVisible = false) }
+        updateState { it.copy(isCreateNewListDialogVisible = false, listName = "") }
     }
 
     override fun onNavigateToLoginClicked() {

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsViewModel.kt
@@ -129,6 +129,7 @@ class MovieDetailsViewModel @Inject constructor(
                 isAddToListDialogVisible = false,
                 isCreateNewListDialogVisible = false,
                 selectedList = null,
+                listName = "",
             )
         }
     }


### PR DESCRIPTION
## Description
This PR improves UX by resetting the list name when the **"Create New List" dialog** is dismissed.

---

## Changes Made
List the changes introduced in this pull request:

- Cleared the `listName` state in both:
  - `MovieDetailsViewModel`
  - `UserListsViewModel`

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.

[Screencast from 2025-08-07 16-06-29.webm](https://github.com/user-attachments/assets/7f93643b-0297-4636-a515-997fec4439bd)

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---