### PR TITLE
fix show loading state before fetching home screen data

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.amsterdam.ui.screens.home
 
 import android.annotation.SuppressLint
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -128,7 +127,7 @@ private fun HomeScreenContent(
             .windowInsetsPadding(WindowInsets(bottom = LocalScaffoldBottomPadding.current))
     ) {
         if (state.error == HomeUiState.HomeError.NetworkError) {
-            Column (Modifier.fillMaxSize()) {
+            Column(Modifier.fillMaxSize()) {
                 HomeAppBar(
                     onSearchClicked = interactionListener::onClickSearch,
                     modifier = Modifier
@@ -136,7 +135,7 @@ private fun HomeScreenContent(
                         .statusBarsPadding()
                         .padding(horizontal = 16.dp),
                 )
-                Box (
+                Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .fillMaxSize()
@@ -144,7 +143,9 @@ private fun HomeScreenContent(
                 ) {
                     NoNetworkContainer(
                         onClickRetry = interactionListener::onClickRetryLoading,
-                        modifier = Modifier.fillMaxSize().padding(vertical = 8.dp)
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(vertical = 8.dp)
                     )
                 }
             }
@@ -187,7 +188,7 @@ private fun HomeScreenContent(
                     state = state.upcomingMoviesSectionUiState,
                     onChangeMovieGenre = interactionListener::onChangeUpcomingMovieGenre,
                     onMovieClicked = interactionListener::onClickUpcomingMovieCard,
-                    isVisible = !state.isLoading&&state.error == null,
+                    isVisible = !state.isLoading && state.error == null,
                     onVerticalOffsetChange = {
                         upcomingMoviesSectionYOffsetDp = it
                     },

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
@@ -40,6 +40,7 @@ class HomeViewModel @Inject constructor(
     HomeInteractionListener {
 
     init {
+        showHomeScreenDataLoading()
         manageLocaleLanguageUseCase.getAppLanguage()
             .onEach {
                 getHomeScreenData()
@@ -48,6 +49,15 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun getHomeScreenData() {
+        tryToExecute(
+            action = { getHomeScreenDataUseCase() },
+            onSuccess = ::onGetHomeScreenDataSuccess,
+            onError = ::onError,
+            onCompletion = ::onCompletion
+        )
+    }
+
+    private fun showHomeScreenDataLoading() {
         updateState {
             it.copy(
                 isLoading = true,
@@ -61,12 +71,6 @@ class HomeViewModel @Inject constructor(
                 ),
             )
         }
-        tryToExecute(
-            action = { getHomeScreenDataUseCase() },
-            onSuccess = ::onGetHomeScreenDataSuccess,
-            onError = ::onError,
-            onCompletion = ::onCompletion
-        )
     }
 
     private fun onGetHomeScreenDataSuccess(homeScreenData: HomeScreenData) {


### PR DESCRIPTION
## Description
This PR refactors the `HomeViewModel` to display a loading indicator before initiating the data fetching process for the home screen.

Previously, the loading state was set concurrently with the data fetching call. This change ensures that the UI accurately reflects the loading state immediately when data retrieval begins.

The `HomeScreen.kt` was also updated to remove an unused import and adjust minor formatting.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.