### PR TITLE
Fix: reset password flow for password reset in webview

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/resetPassword/components/ResetPasswordWebView.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/resetPassword/components/ResetPasswordWebView.kt
@@ -1,16 +1,12 @@
 package com.amsterdam.ui.screens.resetPassword.components
 
-import android.graphics.Bitmap
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import com.amsterdam.ui.utils.buildResetPasswordFormExistenceCheckScript
-import com.amsterdam.ui.utils.createFormDetector
 
 
 @Composable
@@ -20,9 +16,6 @@ fun ResetPasswordWebView(
     onLoadingStateChanged: (isLoading: Boolean) -> Unit,
     onResetPasswordComplete: () -> Unit,
 ) {
-    val resetPasswordDetector = remember(onResetPasswordComplete) {
-        createFormDetector(onResetPasswordComplete)
-    }
     AndroidView(
         modifier = modifier,
         factory = { context ->
@@ -31,30 +24,37 @@ fun ResetPasswordWebView(
 
                 webViewClient = object : WebViewClient() {
 
-                    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                        super.onPageStarted(view, url, favicon)
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        super.onPageFinished(view, url)
                         onLoadingStateChanged(false)
                     }
 
-                    override fun onPageFinished(view: WebView?, url: String?) {
-                        super.onPageFinished(view, url)
-
-                        view ?: return
-                        val script = buildResetPasswordFormExistenceCheckScript()
-                        view.evaluateJavascript(script) { result ->
-                            val isFormPresent = result?.toBoolean() ?: false
-                            resetPasswordDetector(isFormPresent)
-                        }
-                    }
                     override fun onReceivedError(
-                        view: WebView?, request: WebResourceRequest?, error: WebResourceError?
+                        view: WebView?,
+                        request: WebResourceRequest?,
+                        error: WebResourceError?
                     ) {
                         super.onReceivedError(view, request, error)
                         onLoadingStateChanged(false)
                     }
+
+                    override fun shouldOverrideUrlLoading(
+                        view: WebView?,
+                        request: WebResourceRequest?
+                    ): Boolean {
+                        val newUrl = request?.url?.toString()
+                        val resetPasswordUrl = "https://www.themoviedb.org/reset-password"
+
+                        if (newUrl != null && newUrl != resetPasswordUrl) {
+                            onResetPasswordComplete()
+                            return true
+                        }
+
+                        return false
+                    }
                 }
 
-                onLoadingStateChanged(true)
+                onLoadingStateChanged(false)
                 loadUrl(urlToLoad)
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.
 - bug 26 and 28 -> the login web view page shows up after clicking continue or cancel and doesn't navigate directly to profile screen or login screen related case
---

## Changes Made
List the changes introduced in this pull request:

- Changed The Flow of how reset password works

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.