### PR TITLE
fix: Initialize home screen sections with loading state

### DIFF
--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
@@ -21,23 +21,23 @@ data class HomeUiState(
 ) {
     data class PopularMediaSectionUiState(
         val mediaItems: List<PopularMediaItemUiState> = emptyList(),
-        val isLoading: Boolean = false,
+        val isLoading: Boolean = true,
     )
 
     data class TopRatedMediaSectionUiState(
         val mediaItems: List<MediaItemUiState> = emptyList(),
-        val isLoading: Boolean = false,
+        val isLoading: Boolean = true,
     )
 
     data class ContinueWatchingMediaSectionUiState(
         val mediaItems: List<ContinueWatchingMediaItemUiState> = emptyList(),
-        val isLoading: Boolean = false,
+        val isLoading: Boolean = true,
     )
 
     data class UpcomingMoviesSectionUiState(
         val movies: List<MovieItemUiState> = emptyList(),
         val movieGenres: List<MovieGenreItemUiState> = defaultMovieGenres,
-        val isLoading: Boolean = false,
+        val isLoading: Boolean = true,
     ) {
         fun getSelectedUpcomingMovieGenre(): MovieGenre {
             return movieGenres

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.viewmodel.home
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.models.Mood
@@ -83,13 +84,13 @@ class HomeViewModel @Inject constructor(
         tryToExecute(
             action = { getContinueWatchingScreenDataUseCase(pageSize = 10) },
             onSuccess = ::onGetContinueWatchingScreenDataSuccess,
-            onError = ::onError,
-            onCompletion = ::onCompletion
+            onError = ::onError
         )
     }
 
     private fun onGetContinueWatchingScreenDataSuccess(continueWatchingData: Flow<ContinueWatchingScreenData>) {
         continueWatchingData.onEach {
+            Log.e("onGetContinueWatchingScreenDataSuccess1","sucess")
             updateState { currentState ->
                 currentState.copy(
                     continueWatchingMediaSectionUiState = currentState.continueWatchingMediaSectionUiState.copy(
@@ -275,5 +276,10 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun onCompletion() = updateState { it.copy(isLoading = false) }
+    private fun onCompletion() = updateState { it.copy(isLoading = false,
+        popularMediaSectionUiState = it.popularMediaSectionUiState.copy(isLoading = false),
+        topRatedMediaSectionUiState = it.topRatedMediaSectionUiState.copy(isLoading = false),
+        upcomingMoviesSectionUiState = it.upcomingMoviesSectionUiState.copy(isLoading = false),
+        continueWatchingMediaSectionUiState = it.continueWatchingMediaSectionUiState.copy(isLoading = false)
+        ) }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
the components was conflict with each other when opening the home screen.
This commit modifies the `HomeUiState` to initialize all sections (Popular, Top Rated, Continue Watching, Upcoming Movies) with `isLoading = true`.

Additionally, the `onCompletion` function in `HomeViewModel` is updated to set `isLoading = false` for each individual section UI state, ensuring that loading indicators are correctly managed for each section independently.
---

## Changes Made
List the changes introduced in this pull request:

- HomeUiState
- HomeViewModel

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
Before :

https://github.com/user-attachments/assets/c6b9c6e9-25fc-4df3-9793-38b63b13a673

After : 

https://github.com/user-attachments/assets/ced8addb-740f-4885-86c0-ff1744a46d05

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.