### PR TITLE
Fix: Bug: Handle Mood Picker in Offline Mode

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/HomeScreen.kt
@@ -31,20 +31,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.amsterdam.designsystem.components.snackBar.SnackBarManager
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 import com.amsterdam.domain.models.Mood
 import com.amsterdam.entity.category.MovieGenre
+import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavController
 import com.amsterdam.ui.application.LocalScaffoldBottomPadding
 import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.components.appBar.HomeAppBar
 import com.amsterdam.ui.navigation.Route
+import com.amsterdam.ui.navigation.Route.*
 import com.amsterdam.ui.navigation.Route.MovieDetails
 import com.amsterdam.ui.screens.home.component.MovieMoodPickerDialog
 import com.amsterdam.ui.screens.home.sections.AnimatedSectionVisibility
@@ -67,26 +71,31 @@ fun HomeScreen(modifier: Modifier = Modifier, homeViewModel: HomeViewModel = hil
     val navController = LocalNavController.current
     val state by homeViewModel.state.collectAsStateWithLifecycle()
 
+    val errorGetMoviesByMoodMessage = stringResource(R.string.error_mood_movies_loading)
     LaunchedEffect(Unit) {
         homeViewModel.effect.collectLatest { effect ->
             when (effect) {
-                is NavigateToSearchScreenEffect -> navController.navigate(Route.Search)
+                is NavigateToSearchScreenEffect -> navController.navigate(Search)
 
                 is NavigateToMovieDetailsEffect -> {
                     navController.navigate(MovieDetails(movieId = effect.movieId))
                 }
 
                 is HomeEffect.NavigateToTvShowDetailsEffect -> {
-                    navController.navigate(Route.SeriesDetails(tvShowId = effect.tvShowId))
+                    navController.navigate(SeriesDetails(tvShowId = effect.tvShowId))
                 }
 
                 is HomeEffect.NavigateToTopRatedMoviesEffect -> {
-                    navController.navigate(Route.TopRated)
+                    navController.navigate(TopRated)
                 }
 
                 is HomeEffect.NavigateToContinueWatchingMoviesScreen -> {
-                    navController.navigate(Route.ContinueWatching)
+                    navController.navigate(ContinueWatching)
                 }
+
+                HomeEffect.ShowGetMoviesByMoodErrorSnackBar -> SnackBarManager.showError(
+                    message = errorGetMoviesByMoodMessage
+                )
             }
         }
     }
@@ -178,7 +187,7 @@ private fun HomeScreenContent(
                 item {
                     AnimatedSectionVisibility(visible = !state.isLoading && state.error == null) {
                         MoodPickerSection(
-                            state = state,
+                            state = state.moodPickerUiState,
                             interactionListener = interactionListener
                         )
                     }
@@ -254,7 +263,7 @@ private fun HomeScreenPreview() {
                 override fun onClickShowAllToRatedMovies() {}
                 override fun onClickShowAllContinueWatchingMovies() {}
 
-                override fun onClickMood(mood: Mood) {}
+                override fun onChangeMood(mood: Mood) {}
                 override fun onClickGetNow() {}
                 override fun onDismissMoodPickerDialog() {}
                 override fun onClickViewDetails() {}

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/MoodPickerCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/MoodPickerCard.kt
@@ -19,9 +19,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,6 +40,7 @@ import io.sifr.shaded.modifiers.blur
 @Composable
 fun MoodPickerCard(
     cardMoods: List<CardMood>,
+    selectedMood: CardMood?,
     isButtonEnabled: Boolean,
     isLoading: Boolean,
     modifier: Modifier = Modifier,
@@ -89,9 +87,10 @@ fun MoodPickerCard(
         }
 
         MoodOptionsSection(
-            cardMoods,
-            isButtonEnabled,
-            isLoading,
+            cardMoods = cardMoods,
+            selectedMood = selectedMood,
+            isButtonEnabled = isButtonEnabled,
+            isLoading = isLoading,
             modifier =
                 Modifier
                     .padding(top = 76.dp, start = 2.dp, end = 2.dp, bottom = 2.dp),
@@ -105,13 +104,15 @@ fun MoodPickerCard(
 @Composable
 private fun MoodOptionsSection(
     cardMoods: List<CardMood>,
+    selectedMood: CardMood?,
     isButtonEnabled: Boolean,
     isLoading: Boolean,
     modifier: Modifier = Modifier,
     onSelectMood: (CardMood) -> Unit = {},
     onClickGetNow: () -> Unit = {},
 ) {
-    var selectedIndex by remember { mutableIntStateOf(-1) }
+    //var selectedIndex by remember { mutableIntStateOf(-1) }
+    val selectedIndex = cardMoods.indexOfFirst { it.name == selectedMood?.name }
 
     Column(
         modifier =
@@ -137,10 +138,7 @@ private fun MoodOptionsSection(
                 MoodIcon(
                     iconRes = mood.iconResourceId,
                     isSelected = selectedIndex == index,
-                    onClick = {
-                        selectedIndex = index
-                        onSelectMood(mood)
-                    },
+                    onClick = { onSelectMood(mood) },
                 )
             }
         }
@@ -231,6 +229,8 @@ private fun CustomMoodPickerCardPreview() {
                 CardMood.SAD_DIZZY
             ),
             onSelectMood = {},
+            onClickGetNow = {},
+            selectedMood = CardMood.ANGRY
         )
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/sections/MoodPickerSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/sections/MoodPickerSection.kt
@@ -12,23 +12,24 @@ import com.amsterdam.viewmodel.home.HomeUiState
 
 @Composable
 fun MoodPickerSection(
-    state: HomeUiState,
+    state: HomeUiState.MoodPickerUiState,
     interactionListener: HomeInteractionListener,
     modifier: Modifier=Modifier
 ) {
     MoodPickerCard(
-        cardMoods = state.moodPickerUiState.moods.map {
+        cardMoods = state.moods.map {
             CardMood.getModeByName(
                 it.name
             )
         },
-        isButtonEnabled = state.moodPickerUiState.selectedMood != null,
-        isLoading = state.moodPickerUiState.isLoadingMovies,
+        selectedMood = state.selectedMood?.let { CardMood.getModeByName(it.name) },
+        isButtonEnabled = state.selectedMood != null,
+        isLoading = state.isLoadingMovies,
         modifier = modifier.padding(start = 16.dp, end = 16.dp, top = 26.dp),
         onSelectMood = {
             val mood =
                 Mood.getMoodByName(it.name)
-            interactionListener.onClickMood(mood)
+            interactionListener.onChangeMood(mood)
         },
         onClickGetNow = interactionListener::onClickGetNow
     )

--- a/ui/src/main/res/values-ar/string.xml
+++ b/ui/src/main/res/values-ar/string.xml
@@ -228,6 +228,7 @@
     <!-- - Home  -->
     <string name="upcoming">القادمة</string>
     <string name="no_upcoming_movies_found_for_your_selection">لم يتم العثور على أفلام قادمة لاختيارك.</string>
+    <string name="error_mood_movies_loading">عذرًا! لم نتمكن من العثور على أفلام تناسب مزاجك.</string>
 
     <!-- Details Screen -->
     <string name="there_is_no_gallery">لا توجد صور</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -257,5 +257,6 @@
 
     <string name="added_to_list_successfully">Added to list successfully.</string>
     <string name="failed_to_add_to_list">Failed to add to list.</string>
+    <string name="error_mood_movies_loading">Oops! We couldn’t find movies for that mood.</string>
 
 </resources>

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeEffect.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeEffect.kt
@@ -7,4 +7,6 @@ sealed interface HomeEffect {
     data class NavigateToTvShowDetailsEffect(val tvShowId : Long) : HomeEffect
     object NavigateToTopRatedMoviesEffect : HomeEffect
     object NavigateToContinueWatchingMoviesScreen : HomeEffect
+
+    object ShowGetMoviesByMoodErrorSnackBar: HomeEffect
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeInteractionListener.kt
@@ -13,7 +13,7 @@ interface HomeInteractionListener {
     fun onChangeUpcomingMovieGenre(genre: MovieGenre)
     fun onClickShowAllToRatedMovies()
 
-    fun onClickMood(mood: Mood)
+    fun onChangeMood(mood: Mood)
     fun onClickGetNow()
     fun onDismissMoodPickerDialog()
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiState.kt
@@ -1,5 +1,7 @@
 package com.amsterdam.viewmodel.home
 
+import com.amsterdam.domain.exceptions.AflamiException
+import com.amsterdam.domain.exceptions.NetworkException
 import com.amsterdam.domain.models.Mood
 import com.amsterdam.entity.category.MovieGenre
 import com.amsterdam.viewmodel.shared.defaultMovieGenres
@@ -69,6 +71,7 @@ data class HomeUiState(
         val movies: List<MovieItemUiState> = emptyList(),
         val isLoadingMovies: Boolean = false,
         val openMovieDialog: Boolean = false,
+        val error: HomeError? = null
     )
 
 
@@ -84,5 +87,15 @@ data class HomeUiState(
 
     sealed class HomeError {
         data object NetworkError : HomeError()
+        data object UnknownError : HomeError()
+
+        companion object {
+            fun toHomeErrorUiState(exception: AflamiException): HomeError {
+                return when(exception){
+                    is NetworkException -> NetworkError
+                    else -> UnknownError
+                }
+            }
+        }
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeViewModel.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
+import kotlin.Boolean
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -34,8 +35,8 @@ class HomeViewModel @Inject constructor(
     private val continueWatchingUiStateMapper: ContinueWatchingUiStateMapper,
     private val homeUiStateMapper: HomeUiStateMapper,
     private val getMoviesByMoodUseCase: GetMoviesByMoodUseCase,
-    private val manageLocaleLanguageUseCase: ManageLocaleLanguageUseCase,
-    private val dispatcherProvider: DispatcherProvider,
+    manageLocaleLanguageUseCase: ManageLocaleLanguageUseCase,
+    dispatcherProvider: DispatcherProvider,
 ) : BaseViewModel<HomeUiState, HomeEffect>(HomeUiState(), dispatcherProvider),
     HomeInteractionListener {
 
@@ -185,11 +186,12 @@ class HomeViewModel @Inject constructor(
         sendNewNavigationEffect(HomeEffect.NavigateToTopRatedMoviesEffect)
     }
 
-    override fun onClickMood(mood: Mood) {
+    override fun onChangeMood(mood: Mood) {
         updateState {
             it.copy(
                 moodPickerUiState = it.moodPickerUiState.copy(
                     selectedMood = mood,
+                    isLoadingMovies = false,
                     openMovieDialog = false
                 )
             )
@@ -197,20 +199,50 @@ class HomeViewModel @Inject constructor(
     }
 
     override fun onClickGetNow() {
-        updateState {
-            it.copy(
-                moodPickerUiState = it.moodPickerUiState.copy(
-                    isLoadingMovies = true,
-                    selectedMovie = MovieItemUiState()
-                )
-            )
-        }
+        updateState { it.copy(moodPickerUiState = it.moodPickerUiState.copy(isLoadingMovies = true)) }
+
         val selectedMood = state.value.moodPickerUiState.selectedMood ?: return
         tryToExecute(
             action = { getMoviesByMoodUseCase(selectedMood) },
             onSuccess = ::onGetMoviesByMoodSuccess,
-            onError = ::onError
+            onError = ::onGetMoviesByMoodError
         )
+    }
+
+    private fun onGetMoviesByMoodSuccess(movies: List<Movie>) {
+        if (movies.isEmpty()) {
+            updateState { it.copy(moodPickerUiState = it.moodPickerUiState.copy(isLoadingMovies = false)) }
+            return
+        }
+        val moviesUiStates = homeUiStateMapper.moviesToMoviesItemsUiState(movies)
+        val selectedMovie = moviesUiStates[(0..moviesUiStates.size - 1).random()]
+        updateState {
+            it.copy(
+                moodPickerUiState = it.moodPickerUiState
+                    .copy(
+                        isLoadingMovies = false,
+                        movies = moviesUiStates,
+                        selectedMovie = selectedMovie,
+                        openMovieDialog = true
+                    )
+            )
+        }
+    }
+
+
+    private fun onGetMoviesByMoodError(exception: AflamiException) {
+        updateState {
+            it.copy(
+                moodPickerUiState = it.moodPickerUiState.copy(
+                    error = HomeError.toHomeErrorUiState(exception),
+                    isLoadingMovies = false,
+                    openMovieDialog = false,
+                    selectedMood = null
+                )
+            )
+        }
+
+        sendNewEffect(HomeEffect.ShowGetMoviesByMoodErrorSnackBar)
     }
 
     override fun onDismissMoodPickerDialog() {
@@ -246,26 +278,6 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun onGetMoviesByMoodSuccess(movies: List<Movie>) {
-        if (movies.isEmpty()) {
-            updateState { it.copy(moodPickerUiState = it.moodPickerUiState.copy(isLoadingMovies = false)) }
-            return
-        }
-        val moviesUiStates = homeUiStateMapper.moviesToMoviesItemsUiState(movies)
-        val selectedMovie = moviesUiStates[(0..moviesUiStates.size - 1).random()]
-        updateState {
-            it.copy(
-                moodPickerUiState = it.moodPickerUiState
-                    .copy(
-                        isLoadingMovies = false,
-                        movies = moviesUiStates,
-                        selectedMovie = selectedMovie,
-                        openMovieDialog = true
-                    )
-            )
-        }
-    }
-
     override fun onClickUpcomingMovieCard(id: Long) {
         sendNewNavigationEffect(HomeEffect.NavigateToMovieDetailsEffect(movieId = id))
     }
@@ -274,7 +286,6 @@ class HomeViewModel @Inject constructor(
         updateState {
             it.copy(
                 error = HomeError.NetworkError,
-                moodPickerUiState = it.moodPickerUiState.copy(isLoadingMovies = false)
             )
         }
     }

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/home/HomeViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/home/HomeViewModelTest.kt
@@ -347,7 +347,7 @@ class HomeViewModelTest {
         val selectedMood = Mood.ROMANTIC
 
         // When
-        viewModel.onClickMood(selectedMood)
+        viewModel.onChangeMood(selectedMood)
         advanceUntilIdle()
 
         // Then
@@ -384,7 +384,7 @@ class HomeViewModelTest {
         every { homeUiStateMapper.moviesToMoviesItemsUiState(expectedMovies) } returns expectedUiState
 
         // When
-        viewModel.onClickMood(selectedMood)
+        viewModel.onChangeMood(selectedMood)
         advanceUntilIdle()
 
         viewModel.onClickGetNow()
@@ -403,7 +403,7 @@ class HomeViewModelTest {
             every { homeUiStateMapper.moviesToMoviesItemsUiState(expectedMovies) } returns expectedUiState
 
             // When and Then
-            viewModel.onClickMood(selectedMood)
+            viewModel.onChangeMood(selectedMood)
             advanceUntilIdle()
 
             viewModel.onClickGetNow()
@@ -427,7 +427,7 @@ class HomeViewModelTest {
             every { homeUiStateMapper.moviesToMoviesItemsUiState(expectedMovies) } returns emptyList()
 
             // When
-            viewModel.onClickMood(selectedMood)
+            viewModel.onChangeMood(selectedMood)
             advanceUntilIdle()
 
             viewModel.onClickGetNow()


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request addresses improvements and bug fixes in the **Mood Picker** feature on the Home screen.
---

## Changes Made
List the changes introduced in this pull request:

- **UI State Enhancements**
  - Updated `HomeUiState` to include an `error` field for mood-based movie fetch errors.
  - Added `HomeError.UnknownError` and a `toHomeErrorUiState()` mapper for exception handling.

- **Mood Picker Improvements**
  - `MoodPickerCard` now visually reflects the selected mood.
  - Disabled the **Get Now** button until a mood is selected.
  - Fixed infinite loading issue when clicking **Get Another Movie** in offline mode.

- **ViewModel Refactoring**
  - Renamed `onClickMood` → `onChangeMood` for clarity and consistency.
  - `onClickGetNow` updated to handle errors by clearing mood selection and triggering a snackbar effect.
  - `onError` clears mood-related state on network failure.

- **Error Display**
  - Replaced full-screen error container with **snackbar** for "no internet" scenarios to avoid hiding the entire Home screen.

- **Localization**
  - Added Arabic translation for: _"Oops! We couldn’t find movies for that mood."_

---

## Screenshots (if applicable)
before:

https://github.com/user-attachments/assets/413857b6-8e4c-414f-8255-9e19101709a2


after:

https://github.com/user-attachments/assets/741a8b24-8001-4f31-96f1-d70389a0863c


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.