### PR TITLE
Handle missing UI points in theme dialog

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/selection/ThemeSelectionItem.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/selection/ThemeSelectionItem.kt
@@ -77,7 +77,7 @@ fun ThemeSelectionItem(
                 .padding(start = 8.dp)
         )
         RadioButton(
-            state = if (isSelected) RadioState.Selected else RadioState.Unselected,
+            state = if (isSelected) RadioState.Selected else RadioState.Default,
             onClick = onClick,
             modifier = Modifier,
         )

--- a/ui/src/main/java/com/amsterdam/ui/screens/profile/components/ThemeDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/profile/components/ThemeDialog.kt
@@ -1,14 +1,24 @@
 package com.amsterdam.ui.screens.profile.components
 
-import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -17,6 +27,7 @@ import com.amsterdam.designsystem.components.IconButton
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.designsystem.theme.AppTheme
+import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 import com.amsterdam.ui.R
 import com.amsterdam.ui.components.selection.ThemeSelectionItem
 
@@ -50,7 +61,6 @@ fun DialogContent(
     onChangeTheme: (Boolean) -> Unit,
     onDismiss: () -> Unit
 ) {
-
     Column(
         modifier = Modifier
             .padding(12.dp)
@@ -91,6 +101,16 @@ fun DialogContent(
             text = stringResource(R.string.light),
             trailingIcon = com.amsterdam.designsystem.R.drawable.ic_sun,
         )
+        AnimatedVisibility(
+            visible = !isDarkTheme,
+            modifier = Modifier,
+            enter = fadeIn(tween(durationMillis = 300)) + expandVertically(tween(durationMillis = 300)),
+            exit = fadeOut(tween(durationMillis = 300)) + shrinkVertically(tween(durationMillis = 300))
+        ) {
+            LightContent(
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
 
         ConfirmButton(
             title = stringResource(R.string.apply),
@@ -101,4 +121,45 @@ fun DialogContent(
             modifier = Modifier.padding(top = 24.dp),
         )
     }
+}
+
+@Composable
+private fun LightContent(
+    modifier: Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(shape = RoundedCornerShape(12.dp), color = AppTheme.color.surfaceHigh)
+            .padding(8.dp),
+
+        ) {
+        Image(
+            painter = painterResource(com.amsterdam.designsystem.R.drawable.ic_stars),
+            contentDescription = stringResource(R.string.profile),
+            colorFilter = ColorFilter.tint(AppTheme.color.yellowAccent),
+            modifier = Modifier
+                .padding(end = 8.dp)
+                .size(24.dp)
+        )
+
+        Text(
+            text = stringResource(R.string.brightness_message),
+            style = AppTheme.textStyle.label.small,
+            color = AppTheme.color.yellowAccent,
+            modifier = Modifier.align(Alignment.CenterVertically)
+        )
+    }
+}
+
+
+@ThemeAndLocalePreviews
+@Composable
+private fun ThemeDialogPreview() {
+    ThemeDialog(
+        isDarkTheme = true,
+        onChangeTheme = {},
+        onConfirm = {},
+        onDismiss = {}
+    )
 }

--- a/ui/src/main/res/values-ar/string.xml
+++ b/ui/src/main/res/values-ar/string.xml
@@ -262,4 +262,6 @@
 
     <string name="added_to_list_successfully">تمت الإضافة إلى القائمة بنجاح.</string>
     <string name="failed_to_add_to_list">فشل في الإضافة إلى القائمة.</string>
+
+    <string name="brightness_message">سوف تتعرض لهجوم من قبل مجموعة من الألوان الزاهية!</string>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -258,4 +258,6 @@
     <string name="added_to_list_successfully">Added to list successfully.</string>
     <string name="failed_to_add_to_list">Failed to add to list.</string>
 
+    <string name="brightness_message">You will be attacked by a group of bright colors!</string>
+
 </resources>


### PR DESCRIPTION
## Description
- Handle missing part in theme dialog when select light theme and handle selection item radio button to match the design

---

## Changes Made
- Handle missing part in theme dialog when select light theme.
-  Handle selection item radio button to match the design

---

## Screenshots (if applicable)
<img width="428" height="405" alt="image" src="https://github.com/user-attachments/assets/bf9fc4c2-5b90-483a-9f7b-889f0b78be91" />

<img width="386" height="362" alt="image" src="https://github.com/user-attachments/assets/7c6addcd-cba9-4565-a60e-db52d2bd0f04" />

<img width="402" height="359" alt="image" src="https://github.com/user-attachments/assets/ec4f29d4-76fc-416b-92bf-ebfcde6a51b2" />

<img width="392" height="366" alt="image" src="https://github.com/user-attachments/assets/2ec70f03-05aa-41d4-b163-3f38b19a5463" />

<img width="439" height="328" alt="image" src="https://github.com/user-attachments/assets/23051c51-c478-4a99-a11e-2ecc59499de3" />

---

## Checklist
- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

