### PR TITLE
fix: prevent Tab.Lists from restoring state on reselection

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
+++ b/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
@@ -72,9 +72,9 @@ fun AflamiApp(
                                     popUpTo(Route.Tab.Home) {
                                         saveState = true
                                     }
-
+                                    if (it !is  Route.Tab.Lists) {
                                     launchSingleTop = true
-                                    restoreState = true
+                                    restoreState = true}
                                 }
                             },
                         )


### PR DESCRIPTION
This commit modifies the navigation behavior for the `Tab.Lists` route. Previously, reselecting any tab would restore its state. Now, `Tab.Lists` will not restore its state when reselected, while other tabs will continue to do so. This is achieved by conditionally setting `launchSingleTop` and `restoreState` based on whether the selected tab is `Tab.Lists`.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.