### PR TITLE
Fix restoring state bug when we navigate on different tab

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
+++ b/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
@@ -68,13 +68,15 @@ fun AflamiApp(
                         BottomNavigation(
                             currentDestination = currentDestination,
                             onNavigate = {
-                                navController.navigate(it) {
-                                    popUpTo(Route.Tab.Home) {
-                                        saveState = true
-                                    }
+                                if (currentDestination != it) {
+                                    navController.navigate(it) {
+                                        popUpTo(Route.Tab.Home) {
+                                            saveState = true
+                                        }
 
-                                    launchSingleTop = true
-                                    restoreState = true
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
                                 }
                             },
                         )


### PR DESCRIPTION
## Description
This PR fixes an issue where the app would navigate to the same destination if the user repeatedly tapped on the same bottom navigation item.

The fix involves checking if the current destination is different from the target destination before navigating. This ensures that navigation only occurs if the destination is actually changing.


---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.