### PR TITLE
fix: add success and error snackbars for restriction level updates

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/profile/ProfileScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/profile/ProfileScreen.kt
@@ -49,12 +49,12 @@ fun ProfileScreen(
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
             when (effect) {
-                ProfileEffect.NavigateToLogin -> navController.navigate(Route.Login){
+                ProfileEffect.NavigateToLogin -> navController.navigate(Route.Login) {
                     popUpTo(0)
                 }
 
                 ProfileEffect.NavigateToResetPassword -> {
-                    navController.navigate(Route.ResetPassword){
+                    navController.navigate(Route.ResetPassword) {
                         popUpTo(Route.Tab.Profile)
                     }
                 }
@@ -64,6 +64,7 @@ fun ProfileScreen(
                         message = getProfileErrorMessage(state.profileErrorState, context)
                     )
                 }
+
                 is ProfileEffect.LanguageChanged -> {
                     SnackBarManager.showSuccess(
                         when (state.language) {
@@ -93,6 +94,7 @@ fun ProfileScreen(
                                     context.getString(R.string.light)
                                 )
                             }
+
                             true -> {
                                 context.getString(
                                     R.string.theme_changed,
@@ -122,6 +124,13 @@ fun ProfileScreen(
                 }
 
                 ProfileEffect.NavigateToMyRating -> navController.navigate(Route.MyRating)
+                ProfileEffect.ShowRestrictionLevelUpdateErrorSnackBar -> SnackBarManager.showError(
+                    context.getString(R.string.save_restriction_error)
+                )
+
+                ProfileEffect.ShowRestrictionLevelUpdateSuccessSnackBar -> SnackBarManager.showSuccess(
+                    context.getString(R.string.save_restriction_success)
+                )
             }
         }
     }

--- a/ui/src/main/res/values-ar/string.xml
+++ b/ui/src/main/res/values-ar/string.xml
@@ -251,7 +251,8 @@
     <string name="theme_not_changed">لم يتم تغيير النمط، يرجى المحاولة مرة أخرى</string>
 
     <string name="failed_to_load_user_data">حدث خطأ أثناء تحميل بيانات المستخدم، يرجى المحاولة مرة أخرى</string>
-
+    <string name="save_restriction_success">تم حفظ مستوى التقييد بنجاح.</string>
+    <string name="save_restriction_error">فشل في حفظ مستوى التقييد. الرجاء المحاولة مرة أخرى.</string>
 
     <plurals name="item_count">
         <item quantity="zero">لا عناصر</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -248,7 +248,8 @@
     <string name="theme_not_changed">Theme not changed, please try again</string>
 
     <string name="failed_to_load_user_data">Failure while loading user data, please try again</string>
-
+    <string name="save_restriction_success">Restriction level saved successfully.</string>
+    <string name="save_restriction_error">Failed to save restriction level. Please try again.</string>
 
     <plurals name="item_count">
         <item quantity="one">%d item</item>

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/profile/ProfileEffect.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/profile/ProfileEffect.kt
@@ -10,4 +10,7 @@ sealed interface ProfileEffect {
     data object NavigateToMyRating: ProfileEffect
     data object ShowError: ProfileEffect
     data object UserDataNotLoaded : ProfileEffect
+
+    data object ShowRestrictionLevelUpdateSuccessSnackBar : ProfileEffect
+    data object ShowRestrictionLevelUpdateErrorSnackBar : ProfileEffect
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/profile/ProfileViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/profile/ProfileViewModel.kt
@@ -348,10 +348,18 @@ class ProfileViewModel @Inject constructor(
 
         tryToExecute(
             action = { saveRestrictionLevel() },
-            onSuccess = { _ -> },
-            onError = ::onError,
+            onSuccess = ::onSaveRestrictionLevelSuccess,
+            onError = ::onSaveRestrictionLevelError,
             onCompletion = ::onSaveRestrictionLevelCompletion
         )
+    }
+
+    private fun onSaveRestrictionLevelSuccess(unit: Unit){
+        sendNewEffect(ProfileEffect.ShowRestrictionLevelUpdateSuccessSnackBar)
+    }
+
+    private fun onSaveRestrictionLevelError(exception: AflamiException){
+        sendNewEffect(ProfileEffect.ShowRestrictionLevelUpdateErrorSnackBar)
     }
 
     override fun onClickRating() {


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request addresses a bug where no snackbar is shown after updating content restriction levels. Now, users will receive appropriate success or error feedback after saving changes.
---

## Changes Made
List the changes introduced in this pull request:

- Added success snackbar on successful restriction level update.
- Added error snackbar on failure to update restriction level.
---

## Screenshots (if applicable)

https://github.com/user-attachments/assets/bd74c1e8-daca-4ea9-b436-4ab51cd523d1


---
## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.
