### PR TITLE
Fix/popular section image loading

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/PopularMediaItemCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/PopularMediaItemCard.kt
@@ -66,7 +66,13 @@ fun PopularMediaItemCard(
                     modifier =
                         Modifier
                             .size(imageWidth, imageHeight)
-                            .clip(RoundedCornerShape(24.dp)),
+                            .clip(RoundedCornerShape(24.dp))
+                            .border(
+                                width = 1.dp,
+                                color = AppTheme.color.stroke,
+                                shape = RoundedCornerShape(24.dp),
+                            )
+                            .background(AppTheme.color.surface),
                     onLoading = { ImageLoadingIndicator() },
                     safetyLevel = safetyLevel,
                     onError = { ImageErrorIndicator() },

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/component/PopularMediaItemCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/component/PopularMediaItemCard.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.ui.screens.home.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/sections/BlurredMediaPoster.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/sections/BlurredMediaPoster.kt
@@ -2,7 +2,6 @@ package com.amsterdam.ui.screens.home.sections
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
@@ -16,7 +15,7 @@ import io.sifr.shaded.blurProcessor.BlurEdgeTreatment
 import io.sifr.shaded.modifiers.blur
 
 @Composable
-fun BoxScope.BlurredMoviePoster(
+fun BlurredMediaPoster(
     posterUrl: String,
     modifier: Modifier = Modifier,
     ) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/sections/PopularSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/sections/PopularSection.kt
@@ -80,7 +80,7 @@ fun LazyListScope.popularSection(
                         targetState = pagerState.currentPage,
                         animationSpec = tween(500, easing = FastOutSlowInEasing)
                     ) { page ->
-                        BlurredMoviePoster(
+                        BlurredMediaPoster(
                             posterUrl = state.mediaItems[page % state.mediaItems.size].posterUrl,
                             modifier = Modifier.offset(y = (-26).dp)
                         )
@@ -102,7 +102,7 @@ fun LazyListScope.popularSection(
                         AutoScrollingPager(pagerState)
                         BoxWithConstraints {
                             val screenWidth = maxWidth
-                            PopularMoviesPager(
+                            PopularMediaPager(
                                 pagerState = pagerState,
                                 state = state,
                                 screenWidth = screenWidth,
@@ -110,7 +110,7 @@ fun LazyListScope.popularSection(
                             )
                         }
 
-                        DisplayGenresForMovie(
+                        DisplayMediaGenres(
                             modifier = Modifier
                                 .zIndex(2f),
                             mediaItem = state.mediaItems[pagerState.currentPage % state.mediaItems.size],
@@ -123,7 +123,7 @@ fun LazyListScope.popularSection(
 }
 
 @Composable
-private fun DisplayGenresForMovie(
+private fun DisplayMediaGenres(
     mediaItem: PopularMediaItemUiState,
     modifier: Modifier = Modifier
 ) {
@@ -181,7 +181,7 @@ private fun AutoScrollingPager(
 }
 
 @Composable
-private fun PopularMoviesPager(
+private fun PopularMediaPager(
     pagerState: PagerState,
     state: HomeUiState.PopularMediaSectionUiState,
     screenWidth: Dp,


### PR DESCRIPTION
## Description

Added background while loading images in popular section instead of being transparent
And renamed some composables related to it as they use both movies & tv shows

---

## Screenshots (if applicable)

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/468080a3-eeca-4d7f-8f4e-53552f4bc9fc" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.