### PR TITLE
refactor: handle NavigationBar to include a 1px top border

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/bottomNavBar/NavigationBar.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/bottomNavBar/NavigationBar.kt
@@ -3,8 +3,13 @@ package com.amsterdam.designsystem.components.bottomNavBar
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.amsterdam.designsystem.theme.AppTheme
 import androidx.compose.material3.NavigationBar as MaterialNavigationBar
+
 
 @Composable
 fun NavigationBar(
@@ -12,8 +17,19 @@ fun NavigationBar(
     containerColor: Color = Color.Unspecified,
     content: @Composable() (RowScope.() -> Unit)
 ) {
+    val borderColor = AppTheme.color.stroke
+    val strokeWidth = 1.dp
+
     MaterialNavigationBar(
-        modifier = modifier,
+        modifier = modifier.drawBehind {
+            val strokeWidthPx = strokeWidth.toPx()
+            drawLine(
+                color = borderColor,
+                start = Offset(0f, 0f),
+                end = Offset(size.width, 0f),
+                strokeWidth = strokeWidthPx
+            )
+        },
         containerColor = containerColor,
         content = content
     )


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request addresses a UI inconsistency by implementing a missing design detail on the application's bottom navigation bar. The goal is to add a 1px top border to the custom NavigationBar component to ensure it perfectly matches the provided Figma design specifications. 

---

## Changes Made

- Modified the NavigationBar composable in designsystem/components/bottomNavBar/NavigationBar.kt.
- Added a 1-pixel-thick top border to the NavigationBar.
- Implemented the border using Modifier.drawBehind for optimal performance, drawing a line directly on the component's canvas.

---

## Screenshots 
![1](https://github.com/user-attachments/assets/e3b777fb-88ba-420e-bf42-66b5b369f579)
![2](https://github.com/user-attachments/assets/be55021b-d167-48c9-93ea-9cfc4beb9ee5)
![3](https://github.com/user-attachments/assets/14d88a23-eb8a-46de-acf1-a5afae91d0de)
![4](https://github.com/user-attachments/assets/fe91e979-41af-405b-bc57-c1180f423567)
![5](https://github.com/user-attachments/assets/3ae5c884-e8c9-4616-8f87-9ef7eea3f185)

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
