### PR TITLE
Refactor/build gradle structure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,11 +10,11 @@ plugins {
 }
 
 android {
-    namespace = "com.amsterdam.aflami"
+    namespace = libs.versions.namespaceAflami.get()
     compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        applicationId = "com.amsterdam.aflami"
+        applicationId = libs.versions.namespaceAflami.get()
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = libs.versions.versionCode.get().toInt()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,12 +62,12 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.appModulesDependencies() {
-    implementation(project(":ui"))
-    implementation(project(":viewModel"))
-    implementation(project(":localDatasource"))
-    implementation(project(":remoteDatasource"))
-    implementation(project(":domain"))
-    implementation(project(":repository"))
+    implementation(projects.ui)
+    implementation(projects.viewModel)
+    implementation(projects.localDatasource)
+    implementation(projects.remoteDatasource)
+    implementation(projects.domain)
+    implementation(projects.repository)
 }
 
 private fun DependencyHandlerScope.firebaseDependencies() {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 pluginManagement {
     repositories {
         gradlePluginPortal()

--- a/designSystem/build.gradle.kts
+++ b/designSystem/build.gradle.kts
@@ -3,9 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
-android {
-    namespace = "com.amsterdam.designsystem"
-}
+android { namespace = libs.versions.namespaceDesignSystem.get() }
 
 dependencies {
     jetpackMaterial3Dependencies()

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
-    api(project(":entity"))
+    api(projects.entity)
 }
 
 private fun DependencyHandlerScope.coroutinesDependencies() {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -3,15 +3,18 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.jvm)
     alias(libs.plugins.kover)
 }
+
 java {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
 }
+
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
+
 dependencies {
     modulesDependencies()
     coroutinesDependencies()

--- a/entity/build.gradle.kts
+++ b/entity/build.gradle.kts
@@ -2,15 +2,18 @@ plugins {
     alias(libs.plugins.android.java.library)
     alias(libs.plugins.jetbrains.kotlin.jvm)
 }
+
 java {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.jvmTarget.get())
 }
+
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
+
 dependencies{
     implementation(libs.kotlinx.datetime)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,6 +54,16 @@ uiToolingPreviewAndroid = "1.8.3"
 uiTooling = "1.8.3"
 splashscreen = "1.0.1"
 
+namespaceAflami= "com.amsterdam.aflami"
+namespaceLocalDatasource = "com.amsterdam.localdatasource"
+namespaceRemoteDataSource = "com.amsterdam.remotedatasource"
+namespaceRepository = "com.amsterdam.repository"
+namespaceViewModel= "com.amsterdam.viewmodel"
+namespaceDesignSystem = "com.amsterdam.designsystem"
+namespaceUi= "com.amsterdam.ui"
+namespaceImageViewer = "com.amsterdam.imageviewer"
+
+
 [libraries]
 android-test-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "androidTestCore" }
 android-test-runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "androidTestCore" }

--- a/imageViewer/build.gradle.kts
+++ b/imageViewer/build.gradle.kts
@@ -3,9 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
-android {
-    namespace = "com.amsterdam.imageviewer"
-}
+android { namespace = libs.versions.namespaceImageViewer.get() }
 
 dependencies {
     tensorFlowDependencies()

--- a/localDatasource/build.gradle.kts
+++ b/localDatasource/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
 }
 
 android {
-    namespace = "com.amsterdam.localdatasource"
+    namespace = libs.versions.namespaceLocalDatasource.get()
+
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments["runnerBuilder"] =

--- a/localDatasource/build.gradle.kts
+++ b/localDatasource/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
-    implementation(project(":repository"))
+    implementation(projects.repository)
 }
 
 private fun DependencyHandlerScope.roomDependencies() {

--- a/remoteDatasource/build.gradle.kts
+++ b/remoteDatasource/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
-    implementation(project(":repository"))
+    implementation(projects.repository)
 }
 
 private fun DependencyHandlerScope.retrofitDependencies() {

--- a/remoteDatasource/build.gradle.kts
+++ b/remoteDatasource/build.gradle.kts
@@ -13,26 +13,13 @@ plugins {
 }
 
 android {
-    namespace = "com.amsterdam.remotedatasource"
+    namespace = libs.versions.namespaceRemoteDataSource.get()
 
-    buildFeatures {
-        buildConfig = true
-    }
+    buildFeatures { buildConfig = true }
 
     defaultConfig {
-        buildConfigField(
-            "String",
-            "BEARER_TOKEN",
-            bearerToken
-
-        )
-
-        buildConfigField(
-            "String",
-            "BASE_URL",
-            baseUrl
-
-        )
+        buildConfigField("String", "BEARER_TOKEN", bearerToken)
+        buildConfigField("String", "BASE_URL", baseUrl)
     }
 }
 

--- a/repository/build.gradle.kts
+++ b/repository/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
 }
 
 android {
-    namespace = "com.amsterdam.repository"
-    buildFeatures {
-        buildConfig = true
-    }
+    namespace = libs.versions.namespaceRepository.get()
+
+    buildFeatures { buildConfig = true }
+
     defaultConfig {
         testInstrumentationRunnerArguments["runnerBuilder"] =
             "de.mannodermaus.junit5.AndroidJUnit5Builder"

--- a/repository/build.gradle.kts
+++ b/repository/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
-    api(project(":domain"))
+    api(projects.domain)
 
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,6 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
+
 pluginManagement {
     includeBuild("build-logic")
     repositories {
@@ -17,7 +20,6 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
 dependencyResolutionManagement {
+    enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
     alias(libs.plugins.hilt)
 }
 
-android {
-    namespace = "com.amsterdam.ui"
-}
+android { namespace = libs.versions.namespaceUi.get() }
 
 dependencies {
     modulesDependencies()

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -27,9 +27,9 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
-    implementation(project(":designSystem"))
-    implementation(project(":viewModel"))
-    implementation(project(":imageViewer"))
+    implementation(projects.designSystem)
+    implementation(projects.viewModel)
+    implementation(projects.imageViewer)
 }
 
 private fun DependencyHandlerScope.navigationDependencies() {

--- a/viewModel/build.gradle.kts
+++ b/viewModel/build.gradle.kts
@@ -13,21 +13,13 @@ plugins {
 }
 
 android {
-    namespace = "com.amsterdam.viewmodel"
-    buildFeatures {
-        buildConfig = true
-    }
+    namespace = libs.versions.namespaceViewModel.get()
+
+    buildFeatures { buildConfig = true }
+
     defaultConfig {
-        buildConfigField(
-            "String",
-            "MOVIE_SIGN_UP_URL",
-            movieSignUp
-        )
-        buildConfigField(
-            "String",
-            "MOVIE_RESET_PASSWORD_URL",
-            movieResetPassword
-        )
+        buildConfigField("String", "MOVIE_SIGN_UP_URL", movieSignUp)
+        buildConfigField("String", "MOVIE_RESET_PASSWORD_URL", movieResetPassword)
     }
 }
 

--- a/viewModel/build.gradle.kts
+++ b/viewModel/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
 }
 
 private fun DependencyHandlerScope.modulesDependencies() {
-    api(project(":domain"))
+    api(projects.domain)
 }
 
 private fun DependencyHandlerScope.coroutinesDependencies() {


### PR DESCRIPTION
# Pull Request Template

## Description
Refactor Gradle build scripts to improve dependency management and module namespace organization:

- Use type-safe project accessors for declaring module dependencies instead of string-based `project(":moduleName")`.
- Centralize Android module namespace definitions in the version catalog (`gradle/libs.versions.toml`).
- Enable the `TYPESAFE_PROJECT_ACCESSORS` feature preview in `settings.gradle.kts` and `build-logic/settings.gradle.kts`.

---

## Changes Made
List the changes introduced in this pull request:
- Enabled `TYPESAFE_PROJECT_ACCESSORS` feature preview in root and build-logic `settings.gradle.kts`.
- Updated module dependencies in `build.gradle.kts` files to use `projects.moduleName` accessors.
- Moved module namespace declarations from individual `build.gradle.kts` files to `gradle/libs.versions.toml`.
- Refactored `settings.gradle.kts` to reflect new feature preview placement.
---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.