### PR TITLE
Remove add to list option from series details screen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -56,9 +56,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.layout.positionOnScreen
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -203,7 +201,6 @@ fun SeriesDetailsContent(
     }
 
     val screenWidthDp by remember { mutableStateOf(configuration.screenWidthDp.dp) }
-    var seriesExtrasSectionYOffsetDp by remember { mutableStateOf(0.dp) }
     val animationDuration by remember { mutableIntStateOf(1000) }
     val surface = AppTheme.color.surface
     val transparent = AppTheme.color.surface.copy(alpha = 0f)
@@ -427,11 +424,7 @@ fun SeriesDetailsContent(
                             )
                             SeriesExtrasSection(
                                 modifier = Modifier
-                                    .padding(top = 12.dp)
-                                    .onGloballyPositioned { coordinates ->
-                                        seriesExtrasSectionYOffsetDp =
-                                            coordinates.positionOnScreen().y.dp
-                                    },
+                                    .padding(top = 12.dp),
                                 extras = state.extraItem,
                                 onClickExtras = seriesDetailsInteractionListener::onClickSeriesExtraItem
                             )
@@ -493,10 +486,8 @@ fun SeriesDetailsContent(
                     .padding(horizontal = 16.dp, vertical = 8.dp)
                     .statusBarsPadding(),
                 firstOption = painterResource(R.drawable.ic_outlined_star),
-                lastOption = painterResource(R.drawable.ic_outlined_add_to_favourite),
                 onNavigateBackClicked = seriesDetailsInteractionListener::onNavigateBack,
                 onFirstOptionClicked = seriesDetailsInteractionListener::onClickRate,
-                onLastOptionClicked = seriesDetailsInteractionListener::onAddToListClicked
             )
             HorizontalDivider(color = dividerColor)
         }
@@ -662,7 +653,6 @@ private fun SeriesDetailsContentPreview() {
                 override fun onNavigateBack() {}
                 override fun onClickRetryButton() {}
                 override fun onClickShowAllCast() {}
-                override fun onAddToListClicked() {}
                 override fun onClickRate() {}
                 override fun onClickSeasonMenu(seasonNumber: Int) {}
                 override fun onNavigateToLoginClicked() {}

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsInteractionListener.kt
@@ -7,7 +7,6 @@ interface SeriesDetailsInteractionListener {
     fun onNavigateBack()
     fun onClickRetryButton()
     fun onClickShowAllCast()
-    fun onAddToListClicked()
     fun onClickRate()
     fun onClickSeasonMenu(seasonNumber: Int)
     fun onNavigateToLoginClicked()

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsViewModel.kt
@@ -89,15 +89,6 @@ class SeriesDetailsViewModel @Inject constructor(
         sendNewNavigationEffect(SeriesDetailsEffect.NavigateToCastScreen)
     }
 
-    override fun onAddToListClicked() {
-        viewModelScope.launch {
-            runIfLoggedIn(
-                onLoggedIn = {},
-                onGuest = { showMustLoginDialog(MovieAndSeriesDetailsDialogType.AddToList) }
-            )
-        }
-    }
-
     override fun onClickRate() {
         viewModelScope.launch {
             runIfLoggedIn(

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsViewModelTest.kt
@@ -107,24 +107,6 @@ class SeriesDetailsViewModelTest {
         coEvery { getTvShowDetailsUseCase.invoke(100L) } returns tvShowDetails
     }
 
-
-    @Test
-    fun `onCancelClicked should hide the login dialog`() = runTest {
-        coEvery { getsSessionType.invoke() } returns SessionType.GUEST
-
-
-        advanceUntilIdle()
-
-        viewModel.onAddToListClicked()
-        advanceUntilIdle()
-
-        assertThat(viewModel.state.value.isLoginDialogVisible).isTrue()
-
-        viewModel.onCancelClicked()
-        advanceUntilIdle()
-        assertThat(viewModel.state.value.isLoginDialogVisible).isFalse()
-    }
-
     @Disabled
     @Test
     fun `init should update state with received tv show id`() = runTest {
@@ -235,34 +217,6 @@ class SeriesDetailsViewModelTest {
         // Then
         assertThat(effects).containsExactly(SeriesDetailsEffect.NavigateToCastScreen)
         collectJob.cancel()
-    }
-
-    @Test
-    fun `onAddToListClicked should show login dialog when user is a guest`() = runTest {
-        // Given
-        coEvery { getsSessionType.invoke() } returns SessionType.GUEST
-        advanceUntilIdle()
-
-        // When
-        viewModel.onAddToListClicked()
-        advanceUntilIdle()
-
-        // Then
-        assertThat(viewModel.state.value.isLoginDialogVisible).isTrue()
-    }
-
-    @Test
-    fun `onAddToListClicked should not show login dialog when user is logged in`() = runTest {
-        // Given
-        coEvery { getsSessionType.invoke() } returns SessionType.LOGGED_IN
-        advanceUntilIdle()
-
-        // When
-        viewModel.onAddToListClicked()
-        advanceUntilIdle()
-
-        // Then
-        assertThat(viewModel.state.value.isLoginDialogVisible).isFalse()
     }
 
     @Test


### PR DESCRIPTION
## Description

This comPRit removes the "Add to List" button and its associated logic from the series details screen and view model.

The `onAddToListClicked()` function has been removed from `SeriesDetailsViewModel.kt` and `SeriesDetailsInteractionListener.kt`. Correspondingly, the button and its click handler have been removed from the UI in `SeriesDetailsScreen.kt`.

The `seriesExtrasSectionYOffsetDp` variable, which was used for layout positioning related to this button, has also been removed.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.