### PR TITLE
fix: handle nullable release/air dates in mappers and DTOs

### DIFF
--- a/entity/src/main/java/com/amsterdam/entity/Movie.kt
+++ b/entity/src/main/java/com/amsterdam/entity/Movie.kt
@@ -8,7 +8,7 @@ data class Movie(
     val name: String,
     val description: String,
     val posterUrl: String,
-    val releaseDate: LocalDate,
+    val releaseDate: LocalDate?,
     val categories: List<MovieGenre>,
     val rating: Float,
     val popularity: Double,

--- a/entity/src/main/java/com/amsterdam/entity/TvShow.kt
+++ b/entity/src/main/java/com/amsterdam/entity/TvShow.kt
@@ -8,7 +8,7 @@ data class TvShow(
     val name: String,
     val description: String,
     val posterUrl: String,
-    val airDate: LocalDate,
+    val airDate: LocalDate?,
     val categories: List<TvShowGenre>,
     val rating: Float,
     val popularity: Double,

--- a/repository/src/main/java/com/amsterdam/repository/dto/local/LocalMovieDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/local/LocalMovieDto.kt
@@ -18,7 +18,7 @@ data class LocalMovieDto(
     val name: String,
     val description: String,
     val poster: String,
-    val releaseDate: LocalDate,
+    val releaseDate: LocalDate?,
     val popularity: Double,
     val rating: Float,
     val originCountry: String,

--- a/repository/src/main/java/com/amsterdam/repository/dto/local/LocalTvShowDto.kt
+++ b/repository/src/main/java/com/amsterdam/repository/dto/local/LocalTvShowDto.kt
@@ -18,7 +18,7 @@ data class LocalTvShowDto(
     val name: String,
     val description: String,
     val poster: String,
-    val airDate: LocalDate,
+    val airDate: LocalDate?,
     val rating: Float,
     val popularity: Double,
     val seasonCount: Int,

--- a/repository/src/main/java/com/amsterdam/repository/utils/DateExtensions.kt
+++ b/repository/src/main/java/com/amsterdam/repository/utils/DateExtensions.kt
@@ -3,10 +3,10 @@ package com.amsterdam.repository.utils
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toLocalDate
 
-fun String.toSafeLocalDate(): LocalDate {
+fun String.toSafeLocalDate(): LocalDate? {
     return try {
         this.toLocalDate()
     } catch (_: Exception) {
-        LocalDate.fromEpochDays(0)
+        null
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingUiStateMapper.kt
@@ -13,7 +13,7 @@ fun MovieWatchHistory.toContinueWatchingItemUiState(): ContinueWatchingItemUiSta
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = releaseDate.year.toString(),
+            yearOfRelease = releaseDate?.year.toString(),
             dateAdded = lastWatchedTime,
             mediaType = MediaType.MOVIE
         )
@@ -27,7 +27,7 @@ fun TvShowWatchHistory.toContinueWatchingItemUiState(): ContinueWatchingItemUiSt
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = airDate.year.toString(),
+            yearOfRelease = airDate?.year.toString(),
             dateAdded = lastWatchedTime,
             mediaType = MediaType.TV_SHOW
         )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/continueWatching/ContinueWatchingUiStateMapper.kt
@@ -13,7 +13,7 @@ fun MovieWatchHistory.toContinueWatchingItemUiState(): ContinueWatchingItemUiSta
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = releaseDate.year.toString(),
+            yearOfRelease = releaseDate?.year?.toString() ?: "",
             dateAdded = lastWatchedTime,
             mediaType = MediaType.MOVIE
         )
@@ -27,7 +27,7 @@ fun TvShowWatchHistory.toContinueWatchingItemUiState(): ContinueWatchingItemUiSt
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = airDate.year.toString(),
+            yearOfRelease = airDate?.year?.toString() ?: "",
             dateAdded = lastWatchedTime,
             mediaType = MediaType.TV_SHOW
         )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiStateMapper.kt
@@ -92,7 +92,7 @@ fun MovieWatchHistory.toContinueWatchingMediaItemUiState(): ContinueWatchingHome
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = releaseDate.year.toString(),
+            yearOfRelease = releaseDate?.year.toString(),
             dateAdded = lastWatchedTime,
             mediaType = MediaType.MOVIE
         )
@@ -107,7 +107,7 @@ fun TvShowWatchHistory.toContinueWatchingMediaItemUiState(): ContinueWatchingHom
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = airDate.year.toString(),
+            yearOfRelease = airDate?.year.toString(),
             dateAdded = lastWatchedTime,
             mediaType = MediaType.TV_SHOW
         )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/home/HomeUiStateMapper.kt
@@ -92,7 +92,7 @@ fun MovieWatchHistory.toContinueWatchingMediaItemUiState(): ContinueWatchingHome
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = releaseDate.year.toString(),
+            yearOfRelease = releaseDate?.year?.toString() ?: "",
             dateAdded = lastWatchedTime,
             mediaType = MediaType.MOVIE
         )
@@ -107,7 +107,7 @@ fun TvShowWatchHistory.toContinueWatchingMediaItemUiState(): ContinueWatchingHom
             name = name,
             rate =  rating.toFormattedRating(),
             posterImageUrl = posterUrl,
-            yearOfRelease = airDate.year.toString(),
+            yearOfRelease = airDate?.year?.toString() ?: "",
             dateAdded = lastWatchedTime,
             mediaType = MediaType.TV_SHOW
         )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
@@ -42,7 +42,7 @@ private fun Movie.toSimilarMovieUiState(): SimilarMovieUiState {
         movieId = id,
         rate = rating.toFormattedRating(),
         name = name,
-        productionYear = releaseDate.year.toString(),
+        productionYear = releaseDate?.year?.toString() ?: "",
         posterUrl = posterUrl
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
@@ -42,7 +42,7 @@ private fun Movie.toSimilarMovieUiState(): SimilarMovieUiState {
         movieId = id,
         rate = rating.toFormattedRating(),
         name = name,
-        productionYear = releaseDate.year.toString(),
+        productionYear = releaseDate?.year.toString(),
         posterUrl = posterUrl
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/mapper/toSearchMediaItemUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/mapper/toSearchMediaItemUiState.kt
@@ -11,7 +11,7 @@ fun Movie.toSearchMediaItemUiState(): SearchMediaItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = releaseDate.year.toString(),
+        yearOfRelease = releaseDate?.year.toString(),
         rate = rating.toFormattedRating(),
         mediaType = MediaType.MOVIE
     )
@@ -22,7 +22,7 @@ fun TvShow.toSearchMediaItemUiState(): SearchMediaItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = airDate.year.toString(),
+        yearOfRelease = airDate?.year.toString(),
         rate = rating.toFormattedRating(),
         mediaType = MediaType.TV_SHOW
     )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/search/mapper/toSearchMediaItemUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/search/mapper/toSearchMediaItemUiState.kt
@@ -11,7 +11,7 @@ fun Movie.toSearchMediaItemUiState(): SearchMediaItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = releaseDate.year.toString(),
+        yearOfRelease = releaseDate?.year?.toString() ?: "",
         rate = rating.toFormattedRating(),
         mediaType = MediaType.MOVIE
     )
@@ -22,7 +22,7 @@ fun TvShow.toSearchMediaItemUiState(): SearchMediaItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = airDate.year.toString(),
+        yearOfRelease = airDate?.year?.toString() ?: "",
         rate = rating.toFormattedRating(),
         mediaType = MediaType.TV_SHOW
     )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
@@ -48,7 +48,7 @@ private fun TvShow.toSimilarTvShowUiState(): SimilarTvShowUiState {
         movieId = id,
         rate = rating.toFormattedRating(),
         name = name,
-        productionYear = airDate.year.toString(),
+        productionYear = airDate?.year?.toString() ?: "",
         posterUrl = posterUrl
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
@@ -48,7 +48,7 @@ private fun TvShow.toSimilarTvShowUiState(): SimilarTvShowUiState {
         movieId = id,
         rate = rating.toFormattedRating(),
         name = name,
-        productionYear = airDate.year.toString(),
+        productionYear = airDate?.year.toString(),
         posterUrl = posterUrl
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/topRated/TopRatedUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/topRated/TopRatedUiStateMapper.kt
@@ -33,7 +33,7 @@ fun Movie.toTopRatedMediaItemUiState(): TopRatedMediaItemUiState {
         name = name,
         rate = rating.toFormattedRating(),
         posterImageUrl = posterUrl,
-        yearOfRelease = releaseDate.year.toString(),
+        yearOfRelease = releaseDate?.year?.toString() ?: "",
         mediaType = MediaType.MOVIE
     )
 }
@@ -45,7 +45,7 @@ fun TvShow.toTopRatedMediaItemUiState(): TopRatedMediaItemUiState {
         name = name,
         rate = rating.toFormattedRating(),
         posterImageUrl = posterUrl,
-        yearOfRelease = airDate.year.toString(),
+        yearOfRelease = airDate?.year?.toString() ?: "",
         mediaType = MediaType.TV_SHOW
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/topRated/TopRatedUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/topRated/TopRatedUiStateMapper.kt
@@ -33,7 +33,7 @@ fun Movie.toTopRatedMediaItemUiState(): TopRatedMediaItemUiState {
         name = name,
         rate = rating.toFormattedRating(),
         posterImageUrl = posterUrl,
-        yearOfRelease = releaseDate.year.toString(),
+        yearOfRelease = releaseDate?.year.toString(),
         mediaType = MediaType.MOVIE
     )
 }
@@ -45,7 +45,7 @@ fun TvShow.toTopRatedMediaItemUiState(): TopRatedMediaItemUiState {
         name = name,
         rate = rating.toFormattedRating(),
         posterImageUrl = posterUrl,
-        yearOfRelease = airDate.year.toString(),
+        yearOfRelease = airDate?.year.toString(),
         mediaType = MediaType.TV_SHOW
     )
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/watchHistory/WatchHistoryUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/watchHistory/WatchHistoryUiStateMapper.kt
@@ -11,7 +11,7 @@ fun Movie.toWatchHistoryItemUiState(): WatchHistoryItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = releaseDate.year.toString(),
+        yearOfRelease = releaseDate?.year?.toString() ?: "",
         rate = rating.toFormattedRating(),
         mediaType = MediaType.MOVIE
     )
@@ -21,7 +21,7 @@ fun TvShow.toWatchHistoryItemUiState(): WatchHistoryItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = airDate.year.toString(),
+        yearOfRelease = airDate?.year.toString(),
         rate = rating.toFormattedRating(),
         mediaType = MediaType.TV_SHOW
     )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/watchHistory/WatchHistoryUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/watchHistory/WatchHistoryUiStateMapper.kt
@@ -11,7 +11,7 @@ fun Movie.toWatchHistoryItemUiState(): WatchHistoryItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = releaseDate.year.toString(),
+        yearOfRelease = releaseDate?.year.toString(),
         rate = rating.toFormattedRating(),
         mediaType = MediaType.MOVIE
     )
@@ -21,7 +21,7 @@ fun TvShow.toWatchHistoryItemUiState(): WatchHistoryItemUiState {
         id = id,
         name = name,
         posterImageUrl = posterUrl,
-        yearOfRelease = airDate.year.toString(),
+        yearOfRelease = airDate?.year.toString(),
         rate = rating.toFormattedRating(),
         mediaType = MediaType.TV_SHOW
     )


### PR DESCRIPTION
This commit addresses potential NullPointerExceptions by making `releaseDate` in `LocalMovieDto` and `Movie` entity, and `airDate` in `LocalTvShowDto` and `TvShow` entity nullable.

Consequently, all UI state mappers (`TopRatedUiStateMapper`, `MovieDetailsUiStateMapper`, `ContinueWatchingUiStateMapper`, `HomeUiStateMapper`, `toSearchMediaItemUiState`, `SeriesDetailsStateMapper`, `WatchHistoryUiStateMapper`) have been updated to safely access the `year` property of these nullable dates using the safe call operator (`?.`).

The `toSafeLocalDate()` extension function in `DateExtensions.kt` has also been modified to return `null` instead of a default `LocalDate` when date parsing fails, aligning with the nullable date properties.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:


---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.