### PR TITLE
Fix/details rating not shown

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/myRating/MyRatingScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/myRating/MyRatingScreen.kt
@@ -199,7 +199,7 @@ private fun MyRatingContent(
                                     onError = { ImageErrorIndicator() },
                                 )
                             },
-                            movieType = stringResource(R.string.movies),
+                            movieType = stringResource(R.string.tv_shows),
                             movieYear = yearOfRelease,
                             movieTitle = name,
                             movieRating = rate,

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
@@ -9,6 +9,7 @@ import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.ActorMovieUiStat
 import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.ProductionMovieCompanyUiState
 import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.ReviewMovieUiState
 import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.SimilarMovieUiState
+import com.amsterdam.viewmodel.shared.RateDialogUiState
 import com.amsterdam.viewmodel.shared.mappers.toFormattedRating
 import com.amsterdam.viewmodel.utils.movieLengthToHourMinuteString
 import com.amsterdam.viewmodel.utils.toFormattedString
@@ -30,7 +31,8 @@ fun MovieDetails.toUiState(): MovieDetailsUiState {
         similarMovies = similarMovies.toSimilarMoviesUiState(),
         productionCompany = productionCompanies.toProductionMovieCompaniesUiState(),
         gallery = movieGallery,
-        reviews = reviews.map(Review::toUiState)
+        reviews = reviews.map(Review::toUiState),
+        rateDialogUiState = RateDialogUiState(selectedStarIndex = userRate)
     )
 }
 fun Actor.toActorMovieUiState(): ActorMovieUiState = ActorMovieUiState(photo = imageUrl, name = name)

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
@@ -13,6 +13,7 @@ import com.amsterdam.viewmodel.seriesDetails.SeriesDetailsUiState.ReviewTvShowUi
 import com.amsterdam.viewmodel.seriesDetails.SeriesDetailsUiState.SeasonUiState
 import com.amsterdam.viewmodel.seriesDetails.SeriesDetailsUiState.SeasonUiState.EpisodeUiState
 import com.amsterdam.viewmodel.seriesDetails.SeriesDetailsUiState.SimilarTvShowUiState
+import com.amsterdam.viewmodel.shared.RateDialogUiState
 import com.amsterdam.viewmodel.utils.formatDuration
 import com.amsterdam.viewmodel.shared.mappers.toFormattedRating
 import com.amsterdam.viewmodel.utils.toFormattedString
@@ -40,6 +41,7 @@ fun TvShowDetails.toUiState(): SeriesDetailsUiState {
         gallery = gallery,
         postersUrls = posters,
         productionCompanies = productionsCompanies.toProductionTvShowCompanyUiStates(),
+        rateDialogUiState = RateDialogUiState(selectedStarIndex = userRate)
     )
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description
This pull request fixes issues with the rate dialog UI state and TV show type labeling in the details and My Ratings screens.
Ensures that previously submitted ratings for movies and TV shows are displayed in the rate dialog.
Corrects the displayed type for TV shows in the My Ratings screen cards.
---

## Changes Made
List the changes introduced in this pull request:
- fix: Add rate dialog UI state to both movie and series details screens.
- fix: Update string resource to correctly display “TV Show” type instead of “Movie” for rated TV shows.
---

## Screenshots (if applicable)
Before:

https://github.com/user-attachments/assets/3737115e-9423-48b9-8674-4391e2bd0f0c


After:

https://github.com/user-attachments/assets/85d815b4-ff9d-47ef-a671-dfb4be1e2977



---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.