### PR TITLE
refactor: update padding in the bottom of cards

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/categories/CategoriesScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/categories/CategoriesScreen.kt
@@ -115,7 +115,7 @@ private fun CategoriesScreenContent(
                 state = lazyState,
                 verticalArrangement = Arrangement.spacedBy(16.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(top = 17.dp, bottom = 80.dp),
+                contentPadding = PaddingValues(top = 17.dp, bottom = 89.dp),
                 columns = GridCells.Adaptive(160.dp)
             ) {
                 when (state.selectedTabOption) {


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request addresses a minor layout issue in the categories screen where the category cards at the bottom of the list were too close to the navigation bar or the edge of the screen. By increasing the bottom padding, we ensure there is adequate spacing, which improves the overall user experience and visual balance of the screen.

---

## Changes Made

- Increased the bottom padding value within the contentPadding property of the LazyVerticalGrid in the CategoriesScreenContent.
- Ensured consistent spacing at the bottom of the grid regardless of the number of items.

---

## Screenshots 
<img width="293" height="202" alt="image" src="https://github.com/user-attachments/assets/a14e934f-a7a6-4405-93a7-777db99f68b6" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
