### PR TITLE
refactor: fix timer text format for difficulty selection

### DIFF
--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="lets_start">Let’s start</string>
     <string name="and">And</string>
     <string name="sec">Sec</string>
-    <string name="game_settings">%1$d questions, %2$d seconds, %3$d points per question</string>
+    <string name="game_settings">%1$d questions, %2$dsec, %3$d points per question.</string>
     <string name="hint">hint? %1$d Pts.</string>
     <string name="next">Next</string>
     <string name="back_to_menue">Back to menu</string>


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request updates the timer text format in the difficulty selection screen. The purpose is to ensure consistency with the intended UI/UX design, displaying the time as 45sec. instead of 45 seconds and adding a period at the end of the text.

---

## Changes Made

- Updated timer text formatting for all difficulty levels.
- Replaced "seconds" with "sec." in the displayed text.
- Ensured a period is appended at the end of the timer text.

---

## Screenshots 
<img width="242" height="161" alt="image" src="https://github.com/user-attachments/assets/1eb6293a-b9ba-40a9-b5dd-e4b4b5364da9" />
<img width="244" height="172" alt="image" src="https://github.com/user-attachments/assets/e0be46df-344e-4488-9196-f3e6538bfb13" />
<img width="240" height="164" alt="image" src="https://github.com/user-attachments/assets/c86412ad-6ee8-4568-a6d9-cc689904849d" />


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.
