### PR TITLE
Fix/add border to actor card in cast section

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/ActorCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/ActorCard.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.ui.screens.movieDetails.components
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -26,11 +27,15 @@ import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.ActorMovieUiStat
 
 @Composable
 fun ActorCard(modifier: Modifier = Modifier, actor: ActorMovieUiState) {
-    val safetyLevel = LocalRestrictionLevel.current.toSafetyLevel()
     Column(modifier = modifier.width(78.dp)) {
         SafeImageView(
             modifier = Modifier
                 .size(78.dp)
+                .border(
+                    width = 1.dp,
+                    color = AppTheme.color.stroke,
+                    shape = RoundedCornerShape(16.dp)
+                )
                 .clip(RoundedCornerShape(16.dp)),
             model = actor.photo,
             contentDescription = actor.name,

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/component/ActorTvShowCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/component/ActorTvShowCard.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.ui.screens.seriesDetails.component
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -30,6 +31,11 @@ fun ActorTvShowCard(modifier: Modifier = Modifier, actor: ActorTvShowUiState) {
         SafeImageView(
             modifier = Modifier
                 .size(78.dp)
+                .border(
+                    width = 1.dp,
+                    color = AppTheme.color.stroke,
+                    shape = RoundedCornerShape(16.dp)
+                )
                 .clip(RoundedCornerShape(16.dp)),
             model = actor.photo,
             contentDescription = actor.name,


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request updates the UI for the ActorCard component by adding a subtle border. The purpose is to enhance the visual separation of the actor's image and align it with the latest design specifications.
This change affects all instances where ActorCard is used, primarily on the Movie Details and TV Show Details screens, ensuring a consistent look and feel across the application.

---

## Changes Made

- Modified ActorCard.kt: Added a Modifier.border() to the SafeImageView.
- Border Styling: The border is set to 1dp width and uses AppTheme.color.stroke from our design system to maintain consistency.
- Shape Alignment: The border's shape (RoundedCornerShape(16.dp)) is matched with the image's clip shape for a clean finish.
- Impact: The new border is now visible on actor cards displayed on both movie and TV show detail pages.

---

## Screenshots 
<img width="386" height="243" alt="image" src="https://github.com/user-attachments/assets/ccad6aa5-9be3-4bc2-a7ae-8cf13fbfd0f0" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
