### PR TITLE
refactor: add border to gallery image in movie and series screen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/gallerySection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/components/gallerySection.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.ui.screens.movieDetails.components
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyListScope
@@ -11,6 +12,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.components.ImageErrorIndicator
 import com.amsterdam.designsystem.components.ImageLoadingIndicator
+import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.imageviewer.ui.SafeImageView
 import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalRestrictionLevel
@@ -41,6 +43,11 @@ fun LazyListScope.gallerySection(
             SafeImageView(
                 modifier = modifier
                     .weight(1f)
+                    .border(
+                        width = 1.dp,
+                        color = AppTheme.color.stroke,
+                        shape = RoundedCornerShape(12.dp)
+                    )
                     .height(145.dp)
                     .clip(RoundedCornerShape(12.dp)),
                 contentDescription = null,


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request addresses a visual bug on the Details screen where images in the photo gallery were displayed without the required border. This omission made them appear inconsistent with the established UI design.
By re-introducing the border, this fix restores the intended visual appearance, improves the definition of gallery images, and ensures they align with the application's overall design system.

---

## Changes Made

- Modified the composable responsible for rendering gallery images on the Details screen.
- Applied a Modifier.border() to the images, styling it with a 1dp width and using AppTheme.color.stroke for color consistency.
- Ensured the border's RoundedCornerShape matches the image's clip radius for a polished look.

---

## Screenshots 
<img width="339" height="377" alt="image" src="https://github.com/user-attachments/assets/a070622e-5456-49d6-8132-88a1a0d18417" />
<img width="269" height="285" alt="image" src="https://github.com/user-attachments/assets/456e4e43-7793-4a86-bada-2bee422c0904" />

---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.
