### PR TITLE
Fix Details Screen Loading Flicker

### DIFF
--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsViewModel.kt
@@ -42,7 +42,7 @@ class SeriesDetailsViewModel @Inject constructor(
 
     init {
         val tvShowId = args.tvShowId!!
-        updateState { it.copy(tvShowId = tvShowId) }
+        updateState { it.copy(tvShowId = tvShowId, isLoading = true) }
 
         manageLocaleLanguageUseCase.getAppLanguage()
             .onEach {


### PR DESCRIPTION
# Pull Request Template

## Description
Series Details screen briefly shows default placeholder content before loading indicator
---

## Changes Made
List the changes introduced in this pull request:
- Set loading state to true on init
---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
Before:

https://github.com/user-attachments/assets/11f27e71-00f0-4646-bff5-a3def751c335


After:

https://github.com/user-attachments/assets/2587a941-4072-4431-8997-2d5b9bd7929d


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.