### PR TITLE
Fix game bugs

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
@@ -201,7 +201,7 @@ fun CharacterGameQuestion(
                     text = answer,
                     status = state,
                     onClick = {
-                        if (isAnswerCorrect != null && isChoicesEnabled) return@AnswerSelectionItem
+                        if (isChoicesEnabled) return@AnswerSelectionItem
                         onSelectAnswer(index)
                     },
                 )

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
@@ -45,7 +45,6 @@ import com.amsterdam.ui.components.guessGame.GuessPicture
 import com.amsterdam.ui.components.guessGame.TimerComponent
 import com.amsterdam.ui.components.selection.AnswerSelectionItem
 import com.amsterdam.ui.components.selection.AnswerStatus
-import com.amsterdam.ui.navigation.Route
 import com.amsterdam.ui.screens.login.components.LoginBackground
 import com.amsterdam.viewmodel.guessMovieByPosterGame.GuessMovieByPosterGameEffect
 import com.amsterdam.viewmodel.guessMovieByPosterGame.GuessMovieByPosterGameViewModel
@@ -150,6 +149,7 @@ private fun GuessByPosterContent(
                     isHintEnabled = state.isHintEnabled,
                     selectedAnswerIndex = state.selectedAnswerIndex,
                     isAnswerCorrect = state.isAnswerCorrect,
+                    isChoiceEnabled = state.isNextEnabled,
                     onHintClick = interactionListener::onHintClicked,
                     onSelectAnswer = interactionListener::onSelectAnswer,
                 )
@@ -179,6 +179,7 @@ fun GameQuestion(
     isAnswerCorrect: Boolean?,
     isHintEnabled: Boolean,
     modifier: Modifier = Modifier,
+    isChoiceEnabled: Boolean = true,
     onHintClick: () -> Unit = {},
     onSelectAnswer: (Int) -> Unit = {},
 ) {
@@ -218,7 +219,7 @@ fun GameQuestion(
                     text = answer,
                     status = status,
                     onClick = {
-                        if (isAnswerCorrect != null) return@AnswerSelectionItem
+                        if (isChoiceEnabled) return@AnswerSelectionItem
                         onSelectAnswer(index)
                     },
                 )

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
@@ -135,6 +135,7 @@ private fun GameScreenContent(
                     isHintEnabled = state.isHintEnabled,
                     selectedAnswerIndex = state.selectedAnswerIndex,
                     isAnswerCorrect = state.isAnswerCorrect,
+                    isChoiceEnabled = state.isNextEnabled,
                     onHintClick = listener::onUseHint,
                     onSelectAnswer = { answerIndex, answer ->
                         listener
@@ -170,6 +171,7 @@ fun GameQuestion(
     isAnswerCorrect: Boolean?,
     isHintEnabled: Boolean,
     modifier: Modifier = Modifier,
+    isChoiceEnabled: Boolean = true,
     onHintClick: () -> Unit = {},
     onSelectAnswer: (answerIndex: Int, answer: MovieGenre) -> Unit = { _, _ -> },
 ) {
@@ -203,7 +205,7 @@ fun GameQuestion(
                     text = stringResource(answer.uiModel.displayableName),
                     status = state,
                     onClick = {
-                        if (isAnswerCorrect != null) return@AnswerSelectionItem
+                        if (isChoiceEnabled) return@AnswerSelectionItem
                         onSelectAnswer(index, answer)
                     }
                 )

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
@@ -190,7 +190,7 @@ fun ReleaseYearGameQuestion(
                     text = answer,
                     status = state,
                     onClick = {
-                        if (isAnswerCorrect != null && isChoicesEnabled) return@AnswerSelectionItem
+                        if (isChoicesEnabled) return@AnswerSelectionItem
                         onSelectAnswer(index)
                     },
                 )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
@@ -48,8 +48,10 @@ class GuessCharacterGameViewModel @Inject constructor(
     }
 
     private fun onSuccessGetQuestions(questions: List<CharacterDataQuestion>) {
-        updateState { it.copy(questions = questions.toQuestionsUiStateUiState()) }
-        startTheTimer()
+        viewModelScope.launch {
+            updateState { it.copy(questions = questions.toQuestionsUiState()) }
+            startTheTimer()
+        }
     }
 
     private fun startTheTimer() {
@@ -103,7 +105,7 @@ class GuessCharacterGameViewModel @Inject constructor(
                         questions = it.questions.toMutableList().apply {
                             set(
                                 state.value.currentQuestionIndex,
-                                newQuestion.toQuestionUiStateUiState()
+                                newQuestion.toQuestionUiState()
                             )
                         }, isHintEnabled = false
                     )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterQuestionUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterQuestionUiStateMapper.kt
@@ -3,7 +3,7 @@ package com.amsterdam.viewmodel.guessCharacterGame
 import com.amsterdam.domain.useCase.game.character.GenerateCharacterQuestionsUseCase.CharacterDataQuestion
 import com.amsterdam.viewmodel.guessCharacterGame.GuessCharacterUiState.CharacterQuestionUiState
 
-fun CharacterDataQuestion.toQuestionUiStateUiState(): CharacterQuestionUiState {
+fun CharacterDataQuestion.toQuestionUiState(): CharacterQuestionUiState {
     return CharacterQuestionUiState(
         characterImageUrl = this.questionAsPosterUrl,
         characterChoices = this.choices,
@@ -21,5 +21,5 @@ fun CharacterQuestionUiState.toCharacterDataQuestion(): CharacterDataQuestion {
     )
 }
 
-fun List<CharacterDataQuestion>.toQuestionsUiStateUiState(): List<CharacterQuestionUiState> =
-    map { it.toQuestionUiStateUiState() }
+fun List<CharacterDataQuestion>.toQuestionsUiState(): List<CharacterQuestionUiState> =
+    map { it.toQuestionUiState() }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
@@ -49,8 +49,10 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
     }
 
     private fun onSuccessGetQuestions(questions: List<MoviePosterQuestion>) {
-        updateState { it.copy(questions = questions.toQuestionsUiState()) }
-        startTheTimer()
+        viewModelScope.launch {
+            updateState { it.copy(questions = questions.toQuestionsUiState()) }
+            startTheTimer()
+        }
     }
 
     private fun startTheTimer() {


### PR DESCRIPTION
## Description

Wrapped the state update and timer start in `onSuccessGetQuestions` within a `viewModelScope.launch` in both guess character and guess movie by poster view models for better concurrency management.

This PR refactors the answer selection logic in several game screens to disable answer choices once an answer has been selected and the result is known. This prevents users from changing their answer after it has been evaluated.

This PR also renames `toQuestionUiStateUiState` and `toQuestionsUiStateUiState` to `toQuestionUiState` and `toQuestionsUiState` respectively in guess character game and updated their usages.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.