### PR TITLE
Make the Logout text to be clickable instead of the text beside it.

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/profile/components/SettingsDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/profile/components/SettingsDialog.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.components.Dialog
 import com.amsterdam.designsystem.components.Icon
-import com.amsterdam.designsystem.components.buttons.PlainTextButton
+import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
@@ -74,15 +74,13 @@ fun SettingsDialog(
                 title = stringResource(R.string.tired_of_watching),
                 leadingIcon = painterResource(R.drawable.ic_logout),
                 trailingContent = {
-                    PlainTextButton(
-                        title = stringResource(R.string.logout),
+                    Text(
+                        text = stringResource(R.string.logout),
                         style = AppTheme.textStyle.label.medium,
-                        isLoading = false,
-                        isEnabled = true,
-                        isNegative = false,
-                        onClick = onLogoutClick
+                        color = AppTheme.color.primary,
                     )
-                }
+                },
+                onClick = onLogoutClick
             )
         }
     }

--- a/ui/src/main/java/com/amsterdam/ui/screens/profile/components/SettingsDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/profile/components/SettingsDialog.kt
@@ -80,10 +80,9 @@ fun SettingsDialog(
                         isLoading = false,
                         isEnabled = true,
                         isNegative = false,
-                        onClick = {}
+                        onClick = onLogoutClick
                     )
-                },
-                onClick = onLogoutClick
+                }
             )
         }
     }


### PR DESCRIPTION
## Description
Make the Logout text to be clickable instead of the text beside it.

---

## Changes Made
- Make the Logout text to be clickable instead of the text beside it.

---

## Screenshots:

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/98eef3b2-7ce4-466f-9bc2-6763519a574d" controls></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/8a0f84c7-2567-419c-82b8-c2e3cb585732" controls></video>
    </td>
  </tr>
</table>

---

## Checklist
- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
