### PR TITLE
Refactor: Ensure RecentSearchItem handles long titles without hiding cancel icon

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/RecentSearchItem.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/RecentSearchItem.kt
@@ -43,7 +43,7 @@ fun RecentSearchItem(
         )
 
         Text(
-            modifier = Modifier.padding(horizontal = 8.dp).weight(1f),
+            modifier = Modifier.padding(start = 8.dp).weight(1f),
             text = title,
             style = AppTheme.textStyle.body.medium,
             color = AppTheme.color.title,

--- a/ui/src/main/java/com/amsterdam/ui/components/RecentSearchItem.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/RecentSearchItem.kt
@@ -2,7 +2,6 @@ package com.amsterdam.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -33,7 +32,7 @@ fun RecentSearchItem(
             modifier
                 .fillMaxWidth()
                 .clickable { onItemClick(title) }
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -42,30 +41,21 @@ fun RecentSearchItem(
             tint = AppTheme.color.hint,
             contentDescription = title,
         )
-        val maxTitleLength = 50
-        val shortenedTitle = if (title.length > maxTitleLength) {
-            title.take(maxTitleLength) + "…"
-        } else {
-            title
-        }
 
         Text(
-            modifier = Modifier.padding(start = 8.dp),
-            text = shortenedTitle,
+            modifier = Modifier.padding(horizontal = 8.dp).weight(1f),
+            text = title,
             style = AppTheme.textStyle.body.medium,
             color = AppTheme.color.title,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
 
-        Spacer(modifier = Modifier.weight(1f))
-
         Icon(
-            modifier =
-                Modifier
-                    .size(16.dp)
-                    .clip(CircleShape)
-                    .clickable { onCancelClick(title) },
+            modifier = Modifier
+                .size(16.dp)
+                .clip(CircleShape)
+                .clickable { onCancelClick(title) },
             painter = painterResource(R.drawable.ic_cancel),
             tint = AppTheme.color.hint,
             contentDescription = title,
@@ -78,7 +68,7 @@ fun RecentSearchItem(
 private fun RecentSearchItemPreview() {
     AflamiTheme {
         RecentSearchItem(
-            title = "Recent Search",
+            title = "Recent Searchcccccccccccccccccccccccccccccccccccccccccccccccccc",
             onCancelClick = {},
             onItemClick = {},
         )


### PR DESCRIPTION
# Pull Request Template

## Description
Refactor: Update `RecentSearchItem` to handle long titles.  
The `RecentSearchItem` component now correctly displays long titles by using the `weight(1f)` modifier alongside `TextOverflow.Ellipsis` to prevent the cancel icon from disappearing.  
Additionally, unnecessary padding and spacers have been removed to simplify the layout.
---

## Changes Made
List the changes introduced in this pull request:
- Applied `Modifier.weight(1f)` to the `Text` in `RecentSearchItem` to ensure proper space allocation.
- Retained `TextOverflow.Ellipsis` to gracefully truncate long text.
- Removed unnecessary padding and spacers for cleaner layout.

---

## Screenshots (if applicable)
Before:
<img width="281" height="75" alt="{2BB1FF89-C80E-4128-9A59-4B5EBB3452C9}" src="https://github.com/user-attachments/assets/809be98a-68d3-4287-ae07-34731ba588bf" />

After:
<img width="283" height="81" alt="{FF6A6A6E-9425-4120-8B66-0BDA35FC7434}" src="https://github.com/user-attachments/assets/ee29c2dd-8a3a-4d41-a14a-d7c9854b5c76" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
