### PR TITLE
Test/repositories local mappers

### DIFF
--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/CountryLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/CountryLocalMapperTest.kt
@@ -1,47 +1,45 @@
-
 package com.amsterdam.repository.mapper.local
 
 import com.amsterdam.entity.Country
 import com.amsterdam.repository.dto.local.CountryLocalDto
 import com.amsterdam.repository.mapper.toEntity
-import com.amsterdam.repository.mapper.toEntityList
 import com.amsterdam.repository.mapper.toLocalDto
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 class CountryLocalMapperTest {
-
-
     @Test
     fun `toEntity should return Country entity when given LocalCountryDto`() {
-        // When
-        val dto = CountryLocalDto(
-            name = "Egypt",
-            isoCode = "EG",
-            storedLanguage = "en",
-        )
+        val result = countryLocalDto.toEntity()
 
-        // When
-        val result = dto.toEntity()
-
-        // Then
-        assertThat(result.countryName).isEqualTo("Egypt")
-        assertThat(result.countryIsoCode).isEqualTo("EG")
+        assertThat(result.countryName).isEqualTo(EGYPT_NAME)
+        assertThat(result.countryIsoCode).isEqualTo(EGYPT_ISO_CODE)
     }
 
     @Test
     fun `toDto should return LocalCountryDto when given Country entity`() {
-        // Given
-        val entity = Country(
-            countryName = "France",
-            countryIsoCode = "FR"
+        val result = countryEntity.toLocalDto(STORED_LANGUAGE)
+
+        assertThat(result.name).isEqualTo(FRANCE_NAME)
+        assertThat(result.isoCode).isEqualTo(FRANCE_ISO_CODE)
+    }
+
+    companion object {
+        private const val EGYPT_NAME = "Egypt"
+        private const val EGYPT_ISO_CODE = "EG"
+        private const val STORED_LANGUAGE = "en"
+        private const val FRANCE_NAME = "France"
+        private const val FRANCE_ISO_CODE = "FR"
+
+        private val countryLocalDto = CountryLocalDto(
+            name = EGYPT_NAME,
+            isoCode = EGYPT_ISO_CODE,
+            storedLanguage = STORED_LANGUAGE,
         )
 
-        // When
-        val result = entity.toLocalDto("en")
-
-        // Then
-        assertThat(result.name).isEqualTo("France")
-        assertThat(result.isoCode).isEqualTo("FR")
+        private val countryEntity = Country(
+            countryName = FRANCE_NAME,
+            countryIsoCode = FRANCE_ISO_CODE
+        )
     }
 }

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/MovieGenreLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/MovieGenreLocalMapperTest.kt
@@ -8,27 +8,18 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 class MovieGenreLocalMapperTest {
-
-
     @Test
     fun `toEntity should return ALL genre when categoryId is invalid`() {
-        // Given
-        val dto = MovieCategoryLocalDto(
-            categoryId = 100,
-        )
+        val dto = invalidCategoryDto
 
-        // When
         val result = dto.toEntity()
 
-        // Then
         assertThat(result).isEqualTo(MovieGenre.ALL)
     }
 
     @Test
     fun `toEntity should return ALL genre when categoryId is 0`() {
-        val dto = MovieCategoryLocalDto(
-            categoryId = 0,
-            )
+        val dto = zeroCategoryDto
 
         val result = dto.toEntity()
 
@@ -37,8 +28,23 @@ class MovieGenreLocalMapperTest {
 
     @Test
     fun `given list of MovieGenre, when toDtoList is called, then it should return list of ids in order`() {
-        // Given
-        val genres = listOf(
+        val genres = movieGenres
+
+        val result = genres.toDtoList()
+
+        assertThat(result).containsExactlyElementsIn(expectedGenreIds).inOrder()
+    }
+
+    companion object {
+        private val invalidCategoryDto = MovieCategoryLocalDto(
+            categoryId = 100,
+        )
+
+        private val zeroCategoryDto = MovieCategoryLocalDto(
+            categoryId = 0,
+        )
+
+        private val movieGenres = listOf(
             MovieGenre.ALL,
             MovieGenre.DRAMA,
             MovieGenre.COMEDY,
@@ -61,33 +67,9 @@ class MovieGenreLocalMapperTest {
             MovieGenre.SCIENCE_FICTION
         )
 
-        // When
-        val result = genres.toDtoList()
-
-        // Then
-        assertThat(result).containsExactly(
-            35L,
-            18L,
-            35L,
-            10751L,
-            10749L,
-            10770L,
-            99L,
-            14L,
-            36L,
-            27L,
-            10402L,
-            9648L,
-            53L,
-            10752L,
-            37L,
-            28L,
-            12L,
-            16L,
-            80L,
-            878L
-        ).inOrder()
+        private val expectedGenreIds = listOf(
+            35L, 18L, 35L, 10751L, 10749L, 10770L, 99L, 14L, 36L, 27L,
+            10402L, 9648L, 53L, 10752L, 37L, 28L, 12L, 16L, 80L, 878L
+        )
     }
-
 }
-

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/MovieLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/MovieLocalMapperTest.kt
@@ -1,6 +1,4 @@
-
 package com.amsterdam.repository.mapper.local
-
 
 import com.amsterdam.entity.Movie
 import com.amsterdam.repository.dto.local.MovieLocalDto
@@ -11,44 +9,53 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class MovieLocalMapperTest {
-
-
     @Test
     @DisplayName("should return Movie entity when converting from LocalMovieDto")
     fun `toEntity should return Movie when given LocalMovieDto`() {
-        // Given
-        val dto = MovieLocalDto(
-            movieId = 101,
-            name = "Inception",
-            description = "A mind-bending thriller",
-            poster = "poster_url.jpg",
-            releaseDate = LocalDate.parse("2020-01-01"),
-            rating = 8.8f,
-            popularity = 99.5,
-            movieLength = 148,
-            originCountry = "USA",
-            storedLanguage = "en",
+        val dto = movieLocalDto
+
+        val result = dto.toEntity()
+
+        assertThat(result).isEqualTo(expectedMovie)
+    }
+
+    companion object {
+        private const val MOVIE_ID = 101L
+        private const val MOVIE_NAME = "Inception"
+        private const val MOVIE_DESCRIPTION = "A mind-bending thriller"
+        private const val MOVIE_POSTER = "poster_url.jpg"
+        private const val MOVIE_RATING = 8.8f
+        private const val MOVIE_POPULARITY = 99.5
+        private const val MOVIE_LENGTH = 148
+        private const val MOVIE_ORIGIN_COUNTRY = "USA"
+        private const val MOVIE_STORED_LANGUAGE = "en"
+        private val MOVIE_RELEASE_DATE = LocalDate.parse("2020-01-01")
+
+        private val movieLocalDto = MovieLocalDto(
+            movieId = MOVIE_ID,
+            name = MOVIE_NAME,
+            description = MOVIE_DESCRIPTION,
+            poster = MOVIE_POSTER,
+            releaseDate = MOVIE_RELEASE_DATE,
+            rating = MOVIE_RATING,
+            popularity = MOVIE_POPULARITY,
+            movieLength = MOVIE_LENGTH,
+            originCountry = MOVIE_ORIGIN_COUNTRY,
+            storedLanguage = MOVIE_STORED_LANGUAGE,
         )
-        val expected = Movie(
-            id = 101,
-            name = "Inception",
-            description = "A mind-bending thriller",
-            posterUrl = "poster_url.jpg",
-            rating = 8.8f,
-            popularity = 99.5,
-            runTimeInMinutes = 148,
-            originCountry = "USA",
-            releaseDate = LocalDate.parse("2020-01-01"),
+
+        private val expectedMovie = Movie(
+            id = MOVIE_ID,
+            name = MOVIE_NAME,
+            description = MOVIE_DESCRIPTION,
+            posterUrl = MOVIE_POSTER,
+            rating = MOVIE_RATING,
+            popularity = MOVIE_POPULARITY,
+            runTimeInMinutes = MOVIE_LENGTH,
+            originCountry = MOVIE_ORIGIN_COUNTRY,
+            releaseDate = MOVIE_RELEASE_DATE,
             categories = emptyList(),
             videoUrl = "",
         )
-
-        // When
-        val result = dto.toEntity()
-
-        // Then
-        assertThat(result).isEqualTo(expected)
     }
-
 }
-

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/MovieWithCategoriesLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/MovieWithCategoriesLocalMapperTest.kt
@@ -10,48 +10,56 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class MovieWithCategoriesLocalMapperTest {
-
-
     @Test
     @DisplayName("should return Movie when converting from MovieWithCategories")
     fun `toEntity should return Movie when given MovieWithCategories`() {
-        // Given
-        val localMovie = MovieWithCategories(
+        val localMovieWithCategories = movieWithCategories
+
+        val result = localMovieWithCategories.toEntity()
+
+        assertThat(result).isEqualTo(expectedDomainMovie)
+    }
+
+    companion object {
+        private const val MOVIE_ID = 101L
+        private const val MOVIE_NAME = "Inception"
+        private const val MOVIE_DESCRIPTION = "A mind-bending thriller"
+        private const val MOVIE_POSTER = "poster_url.jpg"
+        private const val MOVIE_RATING = 8.8f
+        private const val MOVIE_POPULARITY = 99.5
+        private const val MOVIE_LENGTH = 148
+        private const val MOVIE_ORIGIN_COUNTRY = "USA"
+        private const val MOVIE_STORED_LANGUAGE = "en"
+        private val MOVIE_RELEASE_DATE = LocalDate.parse("2020-01-01")
+
+        private val movieWithCategories = MovieWithCategories(
             movie = MovieLocalDto(
-                movieId = 101,
-                name = "Inception",
-                description = "A mind-bending thriller",
-                poster = "poster_url.jpg",
-                releaseDate = LocalDate.parse("2020-01-01"),
-                rating = 8.8f,
-                popularity = 99.5,
-                movieLength = 148,
-                originCountry = "USA",
-                storedLanguage = "en",
+                movieId = MOVIE_ID,
+                name = MOVIE_NAME,
+                description = MOVIE_DESCRIPTION,
+                poster = MOVIE_POSTER,
+                releaseDate = MOVIE_RELEASE_DATE,
+                rating = MOVIE_RATING,
+                popularity = MOVIE_POPULARITY,
+                movieLength = MOVIE_LENGTH,
+                originCountry = MOVIE_ORIGIN_COUNTRY,
+                storedLanguage = MOVIE_STORED_LANGUAGE,
             ),
             categories = emptyList()
         )
 
-
-        val expectedDomainMovie = Movie(
-            id = 101,
-            name = "Inception",
-            description = "A mind-bending thriller",
-            posterUrl = "poster_url.jpg",
-            rating = 8.8f,
-            popularity = 99.5,
-            runTimeInMinutes = 148,
-            originCountry = "USA",
-            releaseDate = LocalDate.parse("2020-01-01"),
+        private val expectedDomainMovie = Movie(
+            id = MOVIE_ID,
+            name = MOVIE_NAME,
+            description = MOVIE_DESCRIPTION,
+            posterUrl = MOVIE_POSTER,
+            rating = MOVIE_RATING,
+            popularity = MOVIE_POPULARITY,
+            runTimeInMinutes = MOVIE_LENGTH,
+            originCountry = MOVIE_ORIGIN_COUNTRY,
+            releaseDate = MOVIE_RELEASE_DATE,
             categories = emptyList(),
             videoUrl = "",
         )
-        //When
-        val result = localMovie.toEntity()
-        // Then
-        assertThat(result).isEqualTo(expectedDomainMovie)
-
-
     }
-
 }

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/RecentSearchLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/RecentSearchLocalMapperTest.kt
@@ -8,39 +8,39 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class RecentSearchLocalMapperTest {
-
-
     @Test
     @DisplayName("should return searchKeyword from LocalSearchDto")
     fun `toEntity should return searchKeyword`() {
-        // Arrange
-        val dto = SearchLocalDto(
-            searchKeyword = "Inception",
-        )
+        val dto = singleSearchDto
 
-        // Act
         val result = dto.toEntity()
 
-        // Assert
-        assertThat(result).isEqualTo("Inception")
+        assertThat(result).isEqualTo(SEARCH_KEYWORD_1)
     }
 
     @Test
     @DisplayName("should return list of searchKeywords from list of LocalSearchDto")
     fun `toEntityList should return list of searchKeywords`() {
-        // Arrange
-        val dtoList = listOf(
-            SearchLocalDto(
-                searchKeyword = "Inception",
-            ),
-            SearchLocalDto(
-                searchKeyword = "The Dark Knight",
-            )
-        )
-        // Act
+        val dtoList = searchDtoList
+
         val result = dtoList.toEntityList()
-        // Assert
-        assertThat(result).containsExactly("Inception", "The Dark Knight")
+
+        assertThat(result).containsExactlyElementsIn(expectedKeywords).inOrder()
+    }
+
+    companion object {
+        private const val SEARCH_KEYWORD_1 = "Inception"
+        private const val SEARCH_KEYWORD_2 = "The Dark Knight"
+
+        private val singleSearchDto = SearchLocalDto(
+            searchKeyword = SEARCH_KEYWORD_1,
+        )
+
+        private val searchDtoList = listOf(
+            SearchLocalDto(searchKeyword = SEARCH_KEYWORD_1),
+            SearchLocalDto(searchKeyword = SEARCH_KEYWORD_2)
+        )
+
+        private val expectedKeywords = listOf(SEARCH_KEYWORD_1, SEARCH_KEYWORD_2)
     }
 }
-

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/TvShowCategoryLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/TvShowCategoryLocalMapperTest.kt
@@ -10,13 +10,19 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class TvShowCategoryLocalMapperTest {
-
-
     @Test
     @DisplayName("should map LocalTvShowCategoryDto to Category correctly")
     fun `toEntity should map correctly`() {
-        // Arrange
-        val dto = TvShowWithCategories(
+        val dto = tvShowWithCategoriesDto
+
+        val result = dto.toEntity()
+
+        assertThat(result.id).isEqualTo(1)
+        assertThat(result.name).isEqualTo("Drama")
+    }
+
+    companion object {
+        private val tvShowWithCategoriesDto = TvShowWithCategories(
             tvShow = TvShowLocalDto(
                 tvShowId = 1,
                 name = "Drama",
@@ -35,14 +41,5 @@ class TvShowCategoryLocalMapperTest {
                 )
             )
         )
-
-        // Act
-        val result = dto.toEntity()
-
-        // Assert
-        assertThat(result.id).isEqualTo(1)
-        assertThat(result.name).isEqualTo("Drama")
     }
-
-
 }

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/TvShowLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/TvShowLocalMapperTest.kt
@@ -8,10 +8,18 @@ import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.Test
 
 class TvShowLocalMapperTest {
-
     @Test
     fun `toEntity should map LocalTvShowDto to TvShow correctly`() {
-        val dto = TvShowLocalDto(
+        val dto = tvShowLocalDto
+        val expected = expectedMovie
+
+        val result = dto.toEntity()
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    companion object {
+        private val tvShowLocalDto = TvShowLocalDto(
             tvShowId = 1,
             name = "Game of Thrones",
             description = "A fantasy drama series",
@@ -24,7 +32,7 @@ class TvShowLocalMapperTest {
             originCountry = "",
         )
 
-        val expected = Movie(
+        private val expectedMovie = Movie(
             id = 101,
             name = "Inception",
             description = "A mind-bending thriller",
@@ -37,11 +45,5 @@ class TvShowLocalMapperTest {
             categories = emptyList(),
             videoUrl = "",
         )
-
-        val result = dto.toEntity()
-
-        assertThat(result).isEqualTo(expected)
     }
-
 }
-

--- a/repository/src/test/java/com/amsterdam/repository/mapper/local/TvShowWithCategoriesLocalMapperTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/mapper/local/TvShowWithCategoriesLocalMapperTest.kt
@@ -11,12 +11,18 @@ import kotlinx.datetime.LocalDate
 import org.junit.Test
 
 class TvShowWithCategoriesLocalMapperTest {
-
-
     @Test
     fun `toEntity maps TvShowWithCategory to TvShow correctly`() {
-        // Arrange
-        val dto = TvShowWithCategories(
+        val dto = tvShowWithCategoriesDto
+        val expected = expectedTvShow
+
+        val result = dto.toEntity()
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    companion object {
+        private val tvShowWithCategoriesDto = TvShowWithCategories(
             tvShow = TvShowLocalDto(
                 tvShowId = 1,
                 name = "Drama",
@@ -35,13 +41,10 @@ class TvShowWithCategoriesLocalMapperTest {
                 )
             )
         )
-        val expectedGenres = listOf(TvShowGenre.DRAMA, TvShowGenre.CRIME)
 
-        // Act
-        val result = dto.toEntity()
+        private val expectedGenres = listOf(TvShowGenre.DRAMA, TvShowGenre.CRIME)
 
-        // Assert
-        val expected = TvShow(
+        private val expectedTvShow = TvShow(
             id = 1,
             name = "Drama",
             description = "A drama movie",
@@ -53,8 +56,5 @@ class TvShowWithCategoriesLocalMapperTest {
             seasonCount = 3,
             originCountry = "",
         )
-
-        assertThat(result).isEqualTo(expected)
     }
 }
-


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request introduces a significant refactoring of the local mapper test classes to improve code quality, readability, and maintainability.
The primary goal of this change is to centralize test data and constants. Previously, test fixtures were declared inline within each test function, making the tests verbose and harder to maintain. By extracting this data into a companion object for each test class, we separate the test setup (Given) from the execution (When) and assertion (Then) phases. This makes the core logic of each test much clearer and easier to understand at a glance.

---

## Changes Made

- Extracted Test Data: Moved test data fixtures, such as LocalDto objects and expected Entity objects, out of the individual test methods.
- Centralized in Companion Object: Placed all extracted test data and related constants into a companion object at the bottom of each corresponding test class.
- Updated Test Logic: Refactored the test methods to reference the centralized data from the companion object instead of creating it inline.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.