### PR TITLE
Fix top rated data loading and fix caching

### DIFF
--- a/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
@@ -104,14 +104,15 @@ class MovieRepositoryImpl @Inject constructor(
     override suspend fun getTopRatedMovies(
         page: Int,
     ): List<Movie> {
-        return getCachedOrRemoteData<MovieLocalDto, MovieItemRemoteDto, Movie>(
-            deleteExpired = ::deleteExpiredTopRatedMovies,
-            getFromLocal = ::getTopRatedMoviesFromLocal,
-            getFromRemote = { getTopRatedMoviesFromRemote(page) },
-            saveRemoteToDatabase = ::saveTopRatedMovies,
-            mapFromLocalToEntity = MovieLocalDto::toEntity,
-            mapFromRemoteToEntity = { it.toEntity(isPoster = true) }
-        )
+        return if (page > 1) getTopRatedMoviesFromRemote(page).toMovieEntityList(isPoster = true)
+        else getCachedOrRemoteData<MovieLocalDto, MovieItemRemoteDto, Movie>(
+                deleteExpired = ::deleteExpiredTopRatedMovies,
+                getFromLocal = ::getTopRatedMoviesFromLocal,
+                getFromRemote = { getTopRatedMoviesFromRemote(page) },
+                saveRemoteToDatabase = ::saveTopRatedMovies,
+                mapFromLocalToEntity = MovieLocalDto::toEntity,
+                mapFromRemoteToEntity = { it.toEntity(isPoster = true) }
+            )
     }
 
     override suspend fun getMoviesByGenres(movieGenres: List<MovieGenre>, page: Int): List<Movie> {

--- a/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
@@ -16,12 +16,12 @@ import com.amsterdam.repository.datasource.remote.TvShowsRemoteDataSource
 import com.amsterdam.repository.dto.local.TvShowCategoryLocalDto
 import com.amsterdam.repository.dto.local.TvShowLocalDto
 import com.amsterdam.repository.dto.local.relation.TvShowWithCategories
-import com.amsterdam.repository.dto.remote.EpisodeRemoteDto
 import com.amsterdam.repository.dto.remote.CategoryRemoteDto
 import com.amsterdam.repository.dto.remote.CategoryRemoteResponse
+import com.amsterdam.repository.dto.remote.EpisodeRemoteDto
+import com.amsterdam.repository.dto.remote.TvShowDetailsRemoteResponse
 import com.amsterdam.repository.dto.remote.TvShowItemRemoteDto
 import com.amsterdam.repository.dto.remote.TvShowRemoteResponse
-import com.amsterdam.repository.dto.remote.TvShowDetailsRemoteResponse
 import com.amsterdam.repository.mapper.toDto
 import com.amsterdam.repository.mapper.toEntity
 import com.amsterdam.repository.mapper.toEntityList
@@ -62,7 +62,8 @@ class TvShowRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTopRatedTvShows(page: Int): List<TvShow> {
-        return getCachedOrRemoteData<TvShowLocalDto, TvShowItemRemoteDto, TvShow>(
+        return if (page > 1) getTopRatedTvShowsFromRemote(page).toEntityList()
+        else getCachedOrRemoteData<TvShowLocalDto, TvShowItemRemoteDto, TvShow>(
             deleteExpired = ::deleteExpiredTopRatedTvShows,
             getFromLocal = ::getTopRatedTvShowsFromLocal,
             getFromRemote = { getTopRatedTvShowsFromRemote(page) },

--- a/ui/src/main/java/com/amsterdam/ui/screens/topRated/TopRatedScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/topRated/TopRatedScreen.kt
@@ -81,6 +81,15 @@ private fun TopRatedContent(
     interactionListener: TopRatedInteractionListener,
     mediaItems: LazyPagingItems<TopRatedMediaItemUiState>,
 ) {
+    AnimatedSectionVisibility(
+        visible = state.isLoading
+    ) {
+        LoadingContainer(
+            modifier = Modifier
+                .fillMaxSize()
+                .zIndex(10f)
+        )
+    }
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -115,16 +124,6 @@ private fun TopRatedContent(
                     .onSizeChanged { headerHeight = it.height.dp },
                 onNavigateBackClicked = interactionListener::onClickBack
             )
-
-            AnimatedSectionVisibility(
-                visible = state.isLoading
-            ) {
-                LoadingContainer(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .zIndex(10f)
-                )
-            }
 
             AnimatedSectionVisibility(
                 visible = state.error == TopRatedUiState.TopRatedError.NetworkError

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/topRated/TopRatedViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/topRated/TopRatedViewModel.kt
@@ -32,6 +32,7 @@ class TopRatedViewModel @Inject constructor(
     TopRatedInteractionListener {
 
     init {
+        showLoadingState()
         manageLocaleLanguageUseCase.getAppLanguage()
             .onEach {
                 getTopRatedScreenData()
@@ -41,8 +42,7 @@ class TopRatedViewModel @Inject constructor(
     }
 
     private fun getTopRatedScreenData() {
-        updateState { it.copy(isLoading = true) }
-
+        showLoadingState()
         tryToExecute(
             action = {
                 Pager(
@@ -56,10 +56,11 @@ class TopRatedViewModel @Inject constructor(
                             )
                         }
                     }
-                ).flow
-                    .cachedIn(viewModelScope)
+                ).flow.cachedIn(viewModelScope)
             },
-            onSuccess = ::onGetTopRatedMoviesSuccess
+            onSuccess = ::onGetTopRatedMoviesSuccess,
+            onError = ::onError,
+            onCompletion = ::onCompletion
         )
     }
 
@@ -118,4 +119,7 @@ class TopRatedViewModel @Inject constructor(
     override fun onClickBack() {
         sendNewNavigationEffect(TopRatedEffect.NavigateBack)
     }
+
+    private fun showLoadingState() = updateState { it.copy(isLoading = true, error = null) }
+    private fun onCompletion() = updateState { it.copy(isLoading = false, error = null) }
 }

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsViewModelTest.kt
@@ -14,7 +14,6 @@ import com.amsterdam.domain.useCase.preferences.ManageLocaleLanguageUseCase
 import com.amsterdam.domain.useCase.preferences.ManageLocaleLanguageUseCase.Language
 import com.amsterdam.domain.utils.SessionType
 import com.amsterdam.entity.Movie
-import com.amsterdam.entity.Review
 import com.amsterdam.entity.category.MovieGenre
 import com.amsterdam.viewmodel.movieDetails.MovieDetailsUiState.MovieExtras
 import com.amsterdam.viewmodel.utils.TestDispatcherProvider
@@ -31,7 +30,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.toKotlinLocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -218,7 +216,7 @@ class MovieDetailsViewModelTest {
         coEvery { addMovieToListUseCase.invoke(any(), any()) } just Runs
 
         viewModel.effect.test {
-            viewModel.onSaveMovieToList(listId, movieId)
+            viewModel.onSaveMovieToList(listId, listIds = listOf(movieId))
             assertThat(awaitItem()).isEqualTo(MovieDetailsEffect.MovieAddedToListSuccessfully)
         }
     }
@@ -333,10 +331,10 @@ class MovieDetailsViewModelTest {
         viewModel
         advanceUntilIdle()
 
-        viewModel.onSelectedListChange(selectedList)
+        viewModel.onSelectedListChange(listOf(selectedList))
         advanceUntilIdle()
 
-        assertThat(viewModel.state.value.selectedList).isEqualTo(selectedList)
+        assertThat(viewModel.state.value.selectedLists).isEqualTo(listOf(selectedList))
     }
 
     @Test
@@ -400,7 +398,6 @@ class MovieDetailsViewModelTest {
 //endregion
 
     private val movieId: Long = 1
-    private val reviewId = "1"
     private val similarMovieId: Long = 200
     private val newListName = "My New List"
 
@@ -424,29 +421,6 @@ class MovieDetailsViewModelTest {
         moviePosters = emptyList(),
         productionCompanies = emptyList(),
         userRate = null
-    )
-
-    val reviewUsername = "user1"
-
-    val reviews = listOf(
-        Review(
-            id = 1L,
-            reviewerName = "Author 1",
-            reviewerUsername = reviewUsername,
-            rating = 8.5f,
-            content = "This is a great movie!",
-            date = java.time.LocalDate.of(2023, 1, 1).toKotlinLocalDate(),
-            imageUrl = "url1"
-        ),
-        Review(
-            id = 2L,
-            reviewerName = "Author 2",
-            reviewerUsername = "user2",
-            rating = 7.0f,
-            content = "It was okay.",
-            date = java.time.LocalDate.of(2023, 2, 1).toKotlinLocalDate(),
-            imageUrl = "url2"
-        )
     )
 
     private val selectedList = UserListUiState(id = 1L, name = "Test List")


### PR DESCRIPTION
## Description
This Pr  solves the issue of initial loading in top rated screen and fix the pagination in the full screen

---
## Changes Made

- Moved loading indicator to cover the entire screen in `TopRatedScreen`.
- Modified `MovieRepositoryImpl` and `TvShowRepositoryImpl` to fetch subsequent pages of top-rated items directly from remote, bypassing cache.
- Updated `TopRatedViewModel` to show loading state initially and on completion, and to handle errors.
- Corrected `onSaveMovieToList` and `onSelectedListChange` in `MovieDetailsViewModelTest` to use list of IDs instead of single ID.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.