### PR TITLE
Fix/base mdeia card type over flow

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/BaseCard.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/BaseCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -104,15 +105,21 @@ private fun BoxScope.MovieInfoSection(
             overflow = TextOverflow.Ellipsis,
             color = AppTheme.color.onPrimary,
         )
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
             Text(
+                modifier = Modifier.weight(weight = 1f, fill = false),
                 text = movieType,
                 style = AppTheme.textStyle.label.small,
                 color = AppTheme.color.onPrimaryBody,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
             Box(
                 Modifier
-                    .padding(horizontal = 4.dp)
                     .size(3.dp)
                     .clip(CircleShape)
                     .background(AppTheme.color.onPrimaryBody),

--- a/ui/src/main/java/com/amsterdam/ui/screens/categoriesDetails/tvShow/CategoriesTvShowsDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/categoriesDetails/tvShow/CategoriesTvShowsDetailsScreen.kt
@@ -173,7 +173,7 @@ private fun CategoriesTvShowsDetailsContent(
                                         )
                                     },
                                     movieTitle = tvShow.name,
-                                    movieType = stringResource(R.string.tv_shows),
+                                    movieType = stringResource(R.string.tv),
                                     movieYear = tvShow.yearOfRelease,
                                     movieRating = tvShow.rate,
                                     onClick = { interactionListener.onClickTvShowCard(tvShow.id) }

--- a/ui/src/main/java/com/amsterdam/ui/screens/home/sections/UpcomingMoviesSection.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/home/sections/UpcomingMoviesSection.kt
@@ -106,7 +106,7 @@ fun LazyListScope.upcomingMoviesSection(
                                 onError = { ImageErrorIndicator() },
                             )
                         },
-                        movieType = stringResource(R.string.movies),
+                        movieType = stringResource(R.string.movie),
                         movieYear = movie.yearOfRelease,
                         movieTitle = movie.name,
                         movieRating = movie.rate,


### PR DESCRIPTION
# Pull Request Template

## Description
fix mediat type text over flow with large fonts

---

## Changes Made
List the changes introduced in this pull request:

- fix mediat type text over flow with large fonts
- replace `TV Shows, Movies` with `TV Show, Movie` for categories screen

---

## Screenshots (if applicable)

<table width="100%">
  <tr>
    <th width="33%">Before</th>
    <th width="33%">After</th>
    <th width="33%">Another Card</th>
  </tr>
  <tr>
    <td width="33%">
      <img src="https://github.com/user-attachments/assets/c1f6f80d-f45c-4e4b-972a-80241ba7a05c" alt="Before" width="100%">
    </td>
    <td width="33%">
      <img src="https://github.com/user-attachments/assets/07929dc8-82f8-4a32-98e2-321f3b5d18b4" alt="After" width="100%">
    </td>
    <td width="33%">
      <img src="https://github.com/user-attachments/assets/d099d105-9e53-44f5-88f4-82a94398784a" alt="Another Card" width="100%">
    </td>
  </tr>
</table>

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
