### PR TITLE
Refactor/ use null for optional string fields for entities

### DIFF
--- a/entity/src/main/java/com/amsterdam/entity/AccountDetails.kt
+++ b/entity/src/main/java/com/amsterdam/entity/AccountDetails.kt
@@ -3,5 +3,5 @@ package com.amsterdam.entity
 data class AccountDetails(
     val accountId: Int,
     val username: String,
-    val avatarUrl: String = ""
+    val avatarUrl: String? = null,
 )

--- a/entity/src/main/java/com/amsterdam/entity/Movie.kt
+++ b/entity/src/main/java/com/amsterdam/entity/Movie.kt
@@ -14,5 +14,5 @@ data class Movie(
     val popularity: Double,
     val originCountry: String,
     val runTimeInMinutes: Int,
-    val videoUrl: String = ""
+    val videoUrl: String? = null,
 )

--- a/entity/src/main/java/com/amsterdam/entity/TvShow.kt
+++ b/entity/src/main/java/com/amsterdam/entity/TvShow.kt
@@ -14,5 +14,5 @@ data class TvShow(
     val popularity: Double,
     val seasonCount: Int,
     val originCountry: String,
-    val videoUrl: String = ""
+    val videoUrl: String? = null,
 )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/movieDetails/MovieDetailsUiStateMapper.kt
@@ -25,7 +25,7 @@ fun MovieDetails.toUiState(): MovieDetailsUiState {
         movieLength = movieLengthToHourMinuteString(movie.runTimeInMinutes),
         originCountry = movie.originCountry,
         description = movie.description,
-        videoUrl = movie.videoUrl,
+        videoUrl = movie.videoUrl ?: "",
         actors = actors.toActorsMovieUiState(),
         extraItem = MovieDetailsUiState.defaultMovieExtras,
         similarMovies = similarMovies.toSimilarMoviesUiState(),

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/profile/ProfileViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/profile/ProfileViewModel.kt
@@ -133,7 +133,7 @@ class ProfileViewModel @Inject constructor(
             state.copy(
                 userInfo = state.userInfo.copy(
                     username = accountDetails.username,
-                    userAvatarUrl = accountDetails.avatarUrl
+                    userAvatarUrl = accountDetails.avatarUrl ?: ""
                 )
             )
         }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/seriesDetails/SeriesDetailsStateMapper.kt
@@ -22,7 +22,7 @@ fun List<Episode>.toUiState() = map(Episode::toUiState)
 
 fun TvShowDetails.toUiState(): SeriesDetailsUiState {
     return SeriesDetailsUiState(
-        videoUrl = tvShow.videoUrl,
+        videoUrl = tvShow.videoUrl ?: "",
         tvShowId = tvShow.id,
         rating = tvShow.rating.toFormattedRating(),
         posterUrl = tvShow.posterUrl,


### PR DESCRIPTION
# Pull Request Template

## Description
This PR changes the default value of optional string fields in entities from an empty string (`""`) to `null`.

---

## Changes Made

- Updated entities:
    - `videoUrl` in `Movie` and `TvShow` entities.
    - `avatarUrl` in `AccountDetails` entity.
- These fields are now **nullable** (`String?`) instead of defaulting to an empty string.
- Updated relevant view models to handle `null` values:
    - Fallback to empty string (`""`) where needed for UI display.
    - Ensured `null` handling does not cause runtime crashes.

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.