### PR TITLE
Fix and improve bottom navigation tab switching logic

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
+++ b/ui/src/main/java/com/amsterdam/ui/application/AflamiApp.kt
@@ -63,7 +63,7 @@ fun AflamiApp(
         isDarkTheme = state.isDarkTheme,
     ) {
         CompositionLocalProvider(
-            LocalNavManager provides  navigationManager,
+            LocalNavManager provides navigationManager,
             LocalRestrictionLevel provides restrictionLevel
         ) {
             CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
@@ -71,8 +71,8 @@ fun AflamiApp(
                     bottomBar = {
                         BottomNavigation(
                             currentDestination = currentDestination,
-                            onNavigate = {
-                                navigationManager.toTab(it, currentDestination)
+                            onNavigate = { tab, selectedTab ->
+                                navigationManager.toTab(tab, selectedTab)
                             },
                         )
                     }

--- a/ui/src/main/java/com/amsterdam/ui/components/bottomNavigation/BottomNaviagtion.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/bottomNavigation/BottomNaviagtion.kt
@@ -11,14 +11,13 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
-import com.amsterdam.designsystem.components.bottomNavBar.NavigationBar
 import com.amsterdam.ui.navigation.Route
 
 
 @Composable
 fun BottomNavigation(
     currentDestination: NavDestination?,
-    onNavigate: (Route) -> Unit,
+    onNavigate: (Route, Route) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val visible =
@@ -48,7 +47,9 @@ fun BottomNavigation(
             modifier = modifier,
             items = BottomBarItems.entries,
             selectedBottomBarItems = selectedDestination,
-            onDestinationClicked = { onNavigate(it) },
+            onDestinationClicked = {
+                onNavigate(it, selectedDestination.route)
+            },
         )
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/navigation/NavigationManager.kt
+++ b/ui/src/main/java/com/amsterdam/ui/navigation/NavigationManager.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.State
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
-import androidx.navigation.NavDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 
 @Immutable
@@ -26,25 +25,29 @@ class NavigationManager(
     }
 
     // --- Tabs ---
-    fun toTab(tab: Route, currentDestination: NavDestination?) {
-        if (currentDestination != tab) {
+    fun toTab(tab: Route, selectedDestination: Route) {
+        if (selectedDestination != tab) {
             navController.navigate(tab) {
-                popUpTo(Route.Tab.Home) {
+                navController.popBackStack(
+                    route = Route.Tab.Home,
+                    inclusive = true,
                     saveState = true
-                }
+                )
 
                 launchSingleTop = true
                 restoreState = true
             }
         }
     }
+
     fun toLetsPlay(clearBackStack: Boolean = false) {
         navController.navigate(Route.Tab.LetsPlay) {
-            if (clearBackStack) popUpTo(Route.Tab.Home){
+            if (clearBackStack) popUpTo(Route.Tab.Home) {
                 inclusive = false
             }
         }
     }
+
     fun toHome(clearBackStack: Boolean = false) {
         navController.navigate(Route.Tab.Home) {
             if (clearBackStack) popUpTo(0)


### PR DESCRIPTION
## Description
The `toTab` method in `NavigationManager` now correctly pops the back stack up to the Home tab when switching tabs. This ensures a cleaner navigation history and prevents unexpected behavior when navigating between tabs.

The `onNavigate` lambda in `AflamiApp.kt` and `BottomNavigation.kt` has been updated to pass the selected tab to the `toTab` method, allowing for more precise control over tab navigation.


---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.