### PR TITLE
Rename AppPreferences to AppLocalPreferences

### DIFF
--- a/app/src/main/java/com/amsterdam/aflami/di/localDataSourceModule.kt
+++ b/app/src/main/java/com/amsterdam/aflami/di/localDataSourceModule.kt
@@ -5,7 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.dataStoreFile
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import com.amsterdam.localdatasource.dataStore.AppPreferencesImpl
+import com.amsterdam.localdatasource.dataStore.AppLocalPreferencesDataStore
 import com.amsterdam.localdatasource.dataStore.AuthenticationLocalDataSourceImpl
 import com.amsterdam.localdatasource.roomDataBase.AflamiDatabase
 import com.amsterdam.localdatasource.roomDataBase.datasource.CategoryLocalDataSourceImpl
@@ -16,7 +16,7 @@ import com.amsterdam.localdatasource.roomDataBase.datasource.ProfileLocalDataSou
 import com.amsterdam.localdatasource.roomDataBase.datasource.RecentSearchLocalDataSourceImpl
 import com.amsterdam.localdatasource.roomDataBase.datasource.TvShowLocalDataSourceImpl
 import com.amsterdam.localdatasource.roomDataBase.datasource.WatchHistoryLocalDataSourceImpl
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.AuthenticationLocalDataSource
 import com.amsterdam.repository.datasource.local.CategoryLocalDataSource
 import com.amsterdam.repository.datasource.local.CountryLocalDataSource
@@ -103,8 +103,8 @@ abstract class LocalDataSourceBindsModule {
     @Binds
     @Singleton
     abstract fun bindAppPreferences(
-        appPreferencesImpl: AppPreferencesImpl
-    ): AppPreferences
+        appPreferencesDataStore: AppLocalPreferencesDataStore
+    ): AppLocalPreferences
 
     @Binds
     @Singleton

--- a/localDatasource/src/main/java/com/amsterdam/localdatasource/dataStore/AppLocalPreferencesDataStore.kt
+++ b/localDatasource/src/main/java/com/amsterdam/localdatasource/dataStore/AppLocalPreferencesDataStore.kt
@@ -5,20 +5,19 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import com.amsterdam.localdatasource.dataStore.AppPreferencesImpl.PreferenceKeys.CURRENT_LANGUAGE
-import com.amsterdam.localdatasource.dataStore.AppPreferencesImpl.PreferenceKeys.IS_DARK_THEME
-import com.amsterdam.localdatasource.dataStore.AppPreferencesImpl.PreferenceKeys.IS_ONBOARDING_COMPLETED
-import com.amsterdam.localdatasource.dataStore.AppPreferencesImpl.PreferenceKeys.RESTRICTION_LEVEL
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.localdatasource.dataStore.AppLocalPreferencesDataStore.PreferenceKeys.CURRENT_LANGUAGE
+import com.amsterdam.localdatasource.dataStore.AppLocalPreferencesDataStore.PreferenceKeys.IS_DARK_THEME
+import com.amsterdam.localdatasource.dataStore.AppLocalPreferencesDataStore.PreferenceKeys.IS_ONBOARDING_COMPLETED
+import com.amsterdam.localdatasource.dataStore.AppLocalPreferencesDataStore.PreferenceKeys.RESTRICTION_LEVEL
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
-class AppPreferencesImpl @Inject constructor(
+class AppLocalPreferencesDataStore @Inject constructor(
     private val dataStore: DataStore<Preferences>
-) : AppPreferences {
+) : AppLocalPreferences {
 
     override suspend fun setAppLanguage(language: String) {
         dataStore.edit { preferences ->

--- a/localDatasource/src/test/java/com/amsterdam/localdatasource/dataStore/AppLocalPreferencesDataStoreTest.kt
+++ b/localDatasource/src/test/java/com/amsterdam/localdatasource/dataStore/AppLocalPreferencesDataStoreTest.kt
@@ -6,103 +6,103 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
-class AppPreferencesImplTest : BasePreferencesTest() {
-    private val appPreferencesImpl by lazy {
-        AppPreferencesImpl(dataStore)
+class AppLocalPreferencesDataStoreTest : BasePreferencesTest() {
+    private val appPreferencesDataStore by lazy {
+        AppLocalPreferencesDataStore(dataStore)
     }
 
     @Test
     fun `getAppLanguage should return empty string when no value`() = runTest {
-        val result = appPreferencesImpl.getAppLanguage()
+        val result = appPreferencesDataStore.getAppLanguage()
 
         assertThat(result.first()).isEmpty()
     }
 
     @Test
     fun `getAppLanguage should return app language when has value`() = runTest {
-        appPreferencesImpl.setAppLanguage(appLanguage)
+        appPreferencesDataStore.setAppLanguage(appLanguage)
 
-        val result = appPreferencesImpl.getAppLanguage()
+        val result = appPreferencesDataStore.getAppLanguage()
 
         assertThat(result.first()).isEqualTo(appLanguage)
     }
 
     @Test
     fun `setAppLanguage should save provided value when called`() = runTest {
-        appPreferencesImpl.setAppLanguage(appLanguage)
-        val result = appPreferencesImpl.getAppLanguage()
+        appPreferencesDataStore.setAppLanguage(appLanguage)
+        val result = appPreferencesDataStore.getAppLanguage()
 
         assertThat(result.first()).isEqualTo(appLanguage)
     }
 
     @Test
     fun `getAppTheme should return true when no value`() = runTest {
-        val result = appPreferencesImpl.getAppTheme()
+        val result = appPreferencesDataStore.getAppTheme()
 
         assertThat(result.first()).isTrue()
     }
 
     @Test
     fun `getAppTheme should return app theme when has value`() = runTest {
-        appPreferencesImpl.setAppTheme(appTheme)
+        appPreferencesDataStore.setAppTheme(appTheme)
 
-        val result = appPreferencesImpl.getAppTheme()
+        val result = appPreferencesDataStore.getAppTheme()
 
         assertThat(result.first()).isEqualTo(appTheme)
     }
 
     @Test
     fun `setAppTheme should save provided value when called`() = runTest {
-        appPreferencesImpl.setAppTheme(appTheme)
-        val result = appPreferencesImpl.getAppTheme()
+        appPreferencesDataStore.setAppTheme(appTheme)
+        val result = appPreferencesDataStore.getAppTheme()
 
         assertThat(result.first()).isEqualTo(appTheme)
     }
 
     @Test
     fun `getRestrictionLevel should return STRICT when no value`() = runTest {
-        val result = appPreferencesImpl.getRestrictionLevel()
+        val result = appPreferencesDataStore.getRestrictionLevel()
 
         assertThat(result.first()).isEqualTo(defaultRestrictLevel)
     }
 
     @Test
     fun `getRestrictionLevel should return restrict level when has value`() = runTest {
-        appPreferencesImpl.setRestrictionLevel(restrictLevel)
+        appPreferencesDataStore.setRestrictionLevel(restrictLevel)
 
-        val result = appPreferencesImpl.getRestrictionLevel()
+        val result = appPreferencesDataStore.getRestrictionLevel()
 
         assertThat(result.first()).isEqualTo(restrictLevel)
     }
 
     @Test
     fun `setRestrictionLevel should save provided value when called`() = runTest {
-        appPreferencesImpl.setRestrictionLevel(restrictLevel)
-        val result = appPreferencesImpl.getRestrictionLevel()
+        appPreferencesDataStore.setRestrictionLevel(restrictLevel)
+        val result = appPreferencesDataStore.getRestrictionLevel()
 
         assertThat(result.first()).isEqualTo(restrictLevel)
     }
 
     @Test
     fun `isOnboardingCompleted should return false when no value`() = runTest {
-        val result = appPreferencesImpl.isOnboardingCompleted()
+        val result = appPreferencesDataStore.isOnboardingCompleted()
 
         assertThat(result).isFalse()
     }
 
     @Test
     fun `isOnboardingCompleted should return is onboarding completed when has value`() = runTest {
-        appPreferencesImpl.setOnboardingCompleted(isOnboardingCompleted)
+        appPreferencesDataStore.setOnboardingCompleted(isOnboardingCompleted)
 
-        val result = appPreferencesImpl.isOnboardingCompleted()
+        val result = appPreferencesDataStore.isOnboardingCompleted()
 
         assertThat(result).isEqualTo(isOnboardingCompleted)
     }
 
     @Test
     fun `setOnboardingCompleted should save provided value when called`() = runTest {
-        appPreferencesImpl.setAppTheme(isOnboardingCompleted)
-        val result = appPreferencesImpl.getAppTheme()
+        appPreferencesDataStore.setAppTheme(isOnboardingCompleted)
+        val result = appPreferencesDataStore.getAppTheme()
 
         assertThat(result.first()).isEqualTo(isOnboardingCompleted)
     }

--- a/repository/src/main/java/com/amsterdam/repository/datasource/local/AppLocalPreferences.kt
+++ b/repository/src/main/java/com/amsterdam/repository/datasource/local/AppLocalPreferences.kt
@@ -2,7 +2,7 @@ package com.amsterdam.repository.datasource.local
 
 import kotlinx.coroutines.flow.Flow
 
-interface AppPreferences {
+interface AppLocalPreferences {
     suspend fun setOnboardingCompleted(isCompleted: Boolean)
     suspend fun isOnboardingCompleted(): Boolean
 

--- a/repository/src/main/java/com/amsterdam/repository/repository/AppPreferencesRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/AppPreferencesRepositoryImpl.kt
@@ -2,14 +2,14 @@ package com.amsterdam.repository.repository
 
 import com.amsterdam.domain.repository.AppPreferencesRepository
 import com.amsterdam.domain.utils.RestrictionLevel
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.mapper.stringToRestrictionLevelEntity
 import com.amsterdam.repository.mapper.toLocalDto
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class AppPreferencesRepositoryImpl @Inject constructor(
-    private val preferences: AppPreferences,
+    private val preferences: AppLocalPreferences,
 ) : AppPreferencesRepository {
     override fun getAppLanguage(): Flow<String> = preferences.getAppLanguage()
 

--- a/repository/src/main/java/com/amsterdam/repository/repository/CountryRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/CountryRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.amsterdam.repository.repository
 
 import com.amsterdam.domain.repository.CountryRepository
 import com.amsterdam.entity.Country
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.CountryLocalDataSource
 import com.amsterdam.repository.datasource.remote.CountryRemoteDataSource
 import com.amsterdam.repository.dto.remote.CountryRemoteDto
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class CountryRepositoryImpl @Inject constructor(
     private val localDataSource: CountryLocalDataSource,
     private val remoteDataSource: CountryRemoteDataSource,
-    private val preferences: AppPreferences
+    private val preferences: AppLocalPreferences
 ) : CountryRepository {
     override suspend fun getCountries(): List<Country> {
         return getCountriesFromLocal()

--- a/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/MovieRepositoryImpl.kt
@@ -7,7 +7,7 @@ import com.amsterdam.entity.Actor
 import com.amsterdam.entity.Country
 import com.amsterdam.entity.Movie
 import com.amsterdam.entity.category.MovieGenre
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.CategoryLocalDataSource
 import com.amsterdam.repository.datasource.local.MovieLocalDataSource
 import com.amsterdam.repository.datasource.remote.CategoryRemoteDataSource
@@ -40,7 +40,7 @@ class MovieRepositoryImpl @Inject constructor(
     private val movieLocalDataSource: MovieLocalDataSource,
     private val categoryRemoteDataSource: CategoryRemoteDataSource,
     private val movieRemoteDataSource: MovieRemoteDataSource,
-    private val preferences: AppPreferences,
+    private val preferences: AppLocalPreferences,
 ) : MovieRepository {
 
     override suspend fun getMoviesByKeyword(

--- a/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/TvShowRepositoryImpl.kt
@@ -8,7 +8,7 @@ import com.amsterdam.entity.Episode
 import com.amsterdam.entity.Season
 import com.amsterdam.entity.TvShow
 import com.amsterdam.entity.category.TvShowGenre
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.CategoryLocalDataSource
 import com.amsterdam.repository.datasource.local.TvShowLocalDataSource
 import com.amsterdam.repository.datasource.remote.CategoryRemoteDataSource
@@ -37,7 +37,7 @@ import kotlin.time.Duration.Companion.days
 class TvShowRepositoryImpl @Inject constructor(
     private val localTvDataSource: TvShowLocalDataSource,
     private val remoteTvDataSource: TvShowsRemoteDataSource,
-    private val preferences: AppPreferences,
+    private val preferences: AppLocalPreferences,
     private val categoryLocalDataSource: CategoryLocalDataSource,
     private val categoryRemoteDataSource: CategoryRemoteDataSource
 ) : TvShowRepository {

--- a/repository/src/main/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImpl.kt
+++ b/repository/src/main/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImpl.kt
@@ -3,7 +3,7 @@ package com.amsterdam.repository.repository
 import com.amsterdam.domain.repository.WatchHistoryRepository
 import com.amsterdam.entity.MovieWatchHistory
 import com.amsterdam.entity.TvShowWatchHistory
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.MovieLocalDataSource
 import com.amsterdam.repository.datasource.local.TvShowLocalDataSource
 import com.amsterdam.repository.datasource.local.WatchHistoryLocalDataSource
@@ -28,7 +28,7 @@ class WatchHistoryRepositoryImpl @Inject constructor(
     private val movieRemoteDataSource : MovieRemoteDataSource,
     private val tvShowLocalDataSource : TvShowLocalDataSource,
     private val tvShowRemoteSource : TvShowsRemoteDataSource,
-    private val preferences : AppPreferences,
+    private val preferences : AppLocalPreferences,
     private val localTvDataSource : TvShowLocalDataSource
 ) : WatchHistoryRepository {
 

--- a/repository/src/test/java/com/amsterdam/repository/repository/AppPreferencesRepositoryImplTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/repository/AppPreferencesRepositoryImplTest.kt
@@ -2,7 +2,7 @@ package com.amsterdam.repository.repository
 
 import com.amsterdam.domain.repository.AppPreferencesRepository
 import com.amsterdam.domain.utils.RestrictionLevel
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.mapper.toLocalDto
 import com.google.common.truth.Truth.assertThat
 import io.mockk.clearAllMocks
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
 class AppPreferencesRepositoryImplTest {
 
     private lateinit var repository: AppPreferencesRepository
-    private val preferences: AppPreferences = mockk()
+    private val preferences: AppLocalPreferences = mockk()
 
     @BeforeEach
     fun setUp() {

--- a/repository/src/test/java/com/amsterdam/repository/repository/CountryRepositoryImplTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/repository/CountryRepositoryImplTest.kt
@@ -2,7 +2,7 @@ package com.amsterdam.repository.repository
 
 import com.amsterdam.domain.repository.CountryRepository
 import com.amsterdam.entity.Country
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.CountryLocalDataSource
 import com.amsterdam.repository.datasource.remote.CountryRemoteDataSource
 import com.amsterdam.repository.dto.local.CountryLocalDto
@@ -24,7 +24,7 @@ class CountryRepositoryImplTest {
 
     private val localDataSource: CountryLocalDataSource = mockk()
     private val remoteDataSource: CountryRemoteDataSource = mockk()
-    private val preferences: AppPreferences = mockk()
+    private val preferences: AppLocalPreferences = mockk()
     private val testLanguage = "en"
 
     @BeforeEach

--- a/repository/src/test/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImplTest.kt
+++ b/repository/src/test/java/com/amsterdam/repository/repository/WatchHistoryRepositoryImplTest.kt
@@ -2,7 +2,7 @@ package com.amsterdam.repository.repository
 
 import com.amsterdam.entity.MovieWatchHistory
 import com.amsterdam.entity.TvShowWatchHistory
-import com.amsterdam.repository.datasource.local.AppPreferences
+import com.amsterdam.repository.datasource.local.AppLocalPreferences
 import com.amsterdam.repository.datasource.local.MovieLocalDataSource
 import com.amsterdam.repository.datasource.local.TvShowLocalDataSource
 import com.amsterdam.repository.datasource.local.WatchHistoryLocalDataSource
@@ -32,7 +32,7 @@ class WatchHistoryRepositoryImplTest {
     private val movieRemoteDataSource: MovieRemoteDataSource = mockk()
     private val tvShowLocalDataSource: TvShowLocalDataSource = mockk()
     private val tvShowRemoteSource: TvShowsRemoteDataSource = mockk()
-    private val preferences: AppPreferences = mockk()
+    private val preferences: AppLocalPreferences = mockk()
     private val localTvDataSource: TvShowLocalDataSource = mockk()
 
 


### PR DESCRIPTION
## Description
This PR renames `AppPreferences` and `AppPreferencesImpl` to `AppLocalPreferences` and `AppLocalPreferencesDataStore` respectively to improve clarity and consistency. The corresponding test file has also been renamed.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.