### PR TITLE
Make getTrendingPeople private

### DIFF
--- a/remoteDatasource/src/main/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImpl.kt
+++ b/remoteDatasource/src/main/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImpl.kt
@@ -13,10 +13,6 @@ class PeopleRemoteDataSourceImpl @Inject constructor(
     private val peopleApiService: PeopleApiService
 ) : PeopleRemoteDataSource {
 
-    override suspend fun getTrendingPeople(page: Int): RemotePeopleResponse {
-        return responseCall { peopleApiService.getTrendingPeople(page = page) }
-    }
-
     override suspend fun getRandomizedTrendingPeople(requiredNumber: Int): List<RemotePeopleItemDto> {
 
         val totalPages = getTrendingPeople(FIRST_PAGE).totalPages
@@ -47,6 +43,10 @@ class PeopleRemoteDataSourceImpl @Inject constructor(
 
     private fun onFilterHighQualityPeopleData(people: RemotePeopleItemDto): Boolean {
         return people.name.isNotBlank() && !people.fullPosterUrl.isNullOrBlank()
+    }
+
+    private suspend fun getTrendingPeople(page: Int): RemotePeopleResponse {
+        return responseCall { peopleApiService.getTrendingPeople(page = page) }
     }
 
     private companion object {

--- a/remoteDatasource/src/main/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImpl.kt
+++ b/remoteDatasource/src/main/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImpl.kt
@@ -20,12 +20,12 @@ class PeopleRemoteDataSourceImpl @Inject constructor(
 
         while (collectedPeople.size < requiredNumber && usedPages.size < totalPages) {
             val peoples = (FIRST_PAGE..totalPages)
-                .random()
-                .also { usedPages.add(it) }
-                .let { page -> getTrendingPeople(page).results }
-                .filter(::onFilterHighQualityPeopleData)
-                .shuffled()
-                .distinctBy(RemotePeopleItemDto::id)
+                    .random()
+                    .also { usedPages.add(it) }
+                    .let { page -> getTrendingPeople(page).results }
+                    .filter(::onFilterHighQualityPeopleData)
+                    .shuffled()
+                    .distinctBy(RemotePeopleItemDto::id)
 
 
             for (people in peoples) {
@@ -44,7 +44,11 @@ class PeopleRemoteDataSourceImpl @Inject constructor(
     }
 
     private suspend fun getTrendingPeople(page: Int): RemotePeopleResponse {
-        return responseCall { peopleApiService.getTrendingPeople(page = page) }
+        return responseCall(
+            execute = {
+                peopleApiService.getTrendingPeople(page = page)
+            }
+        )
     }
 
     private companion object {

--- a/remoteDatasource/src/test/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImplTest.kt
+++ b/remoteDatasource/src/test/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImplTest.kt
@@ -1,6 +1,5 @@
 package com.amsterdam.remotedatasource.datasource
 
-import com.amsterdam.domain.exceptions.NetworkException
 import com.amsterdam.remotedatasource.api.PeopleApiService
 import com.amsterdam.repository.dto.remote.RemotePeopleItemDto
 import com.amsterdam.repository.dto.remote.RemotePeopleResponse
@@ -10,59 +9,12 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class PeopleRemoteDataSourceImplTest {
 
     private val peopleApiService: PeopleApiService = mockk()
     private val peopleRemoteDataSourceImpl: PeopleRemoteDataSourceImpl =
         PeopleRemoteDataSourceImpl(peopleApiService)
-
-    @Test
-    fun `getTrendingPeople should return a list of people on successful API call`() = runTest {
-        coEvery { peopleApiService.getTrendingPeople(any()) } returns trendingPeopleResponse
-
-        val people = peopleRemoteDataSourceImpl.getTrendingPeople(page = 1)
-
-        assertThat(people).isEqualTo(trendingPeopleResponse)
-    }
-
-    @Test
-    fun `getTrendingPeople should call getTrendingPeople exactly once on a successful API call`() =
-        runTest {
-            coEvery { peopleApiService.getTrendingPeople(any()) } returns trendingPeopleResponse
-
-            peopleRemoteDataSourceImpl.getTrendingPeople(page = 1)
-
-            coVerify(exactly = 1) { peopleApiService.getTrendingPeople(any()) }
-        }
-
-    @Test
-    fun `getTrendingPeople should rethrow a NetworkException when the service provider throws one`() =
-        runTest {
-            coEvery { peopleApiService.getTrendingPeople(any()) } throws networkException
-
-            assertThrows<NetworkException> { peopleRemoteDataSourceImpl.getTrendingPeople(page = 1) }
-        }
-
-    @Test
-    fun `getTrendingPeople should return an empty list when the API service returns an empty list`() =
-        runTest {
-            coEvery { peopleApiService.getTrendingPeople(any()) } returns emptyPeopleResponse
-
-            val people = peopleRemoteDataSourceImpl.getTrendingPeople(page = 1)
-
-            assertThat(people.results).isEmpty()
-        }
-
-    @Test
-    fun `getTrendingPeople should call the API exactly once when it returns an empty list`() = runTest {
-        coEvery { peopleApiService.getTrendingPeople(any()) } returns emptyPeopleResponse
-
-        peopleRemoteDataSourceImpl.getTrendingPeople(page = 1)
-
-        coVerify(exactly = 1) { peopleApiService.getTrendingPeople(any()) }
-    }
 
     @Test
     fun `getRandomizedTrendingPeople should return the required number of people`() = runTest {
@@ -127,24 +79,6 @@ class PeopleRemoteDataSourceImplTest {
             assertThat(people).isEmpty()
         }
 
-    private val networkException = NetworkException()
-
-    private val trendingPeopleResponse = RemotePeopleResponse(
-        page = 1,
-        totalPages = 2,
-        totalResults = 4,
-        results = listOf(
-            createPeopleItemDto(id = 1, name = "Person A", profilePath = "path/a.jpg"),
-            createPeopleItemDto(id = 2, name = "Person B", profilePath = "path/b.jpg")
-        )
-    )
-
-    private val emptyPeopleResponse = RemotePeopleResponse(
-        page = 1,
-        totalPages = 1,
-        totalResults = 0,
-        results = emptyList()
-    )
 
     private fun createPeopleItemDto(
         id: Int,

--- a/remoteDatasource/src/test/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImplTest.kt
+++ b/remoteDatasource/src/test/java/com/amsterdam/remotedatasource/datasource/PeopleRemoteDataSourceImplTest.kt
@@ -1,5 +1,6 @@
 package com.amsterdam.remotedatasource.datasource
 
+import com.amsterdam.domain.exceptions.NetworkException
 import com.amsterdam.remotedatasource.api.PeopleApiService
 import com.amsterdam.repository.dto.remote.RemotePeopleItemDto
 import com.amsterdam.repository.dto.remote.RemotePeopleResponse
@@ -9,12 +10,25 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class PeopleRemoteDataSourceImplTest {
 
     private val peopleApiService: PeopleApiService = mockk()
     private val peopleRemoteDataSourceImpl: PeopleRemoteDataSourceImpl =
         PeopleRemoteDataSourceImpl(peopleApiService)
+
+    @Test
+    fun `getTrendingPeople should rethrow a NetworkException when the service provider throws one`() =
+        runTest {
+            coEvery { peopleApiService.getTrendingPeople(any()) } throws NetworkException()
+
+            assertThrows<NetworkException> {
+                peopleRemoteDataSourceImpl.getRandomizedTrendingPeople(
+                    requiredNumber = 5
+                )
+            }
+        }
 
     @Test
     fun `getRandomizedTrendingPeople should return the required number of people`() = runTest {
@@ -135,7 +149,8 @@ class PeopleRemoteDataSourceImplTest {
         createPeopleItemDto(id = 2, name = "Jerry", profilePath = null)
     )
 
-    private val firstPageForRandomizedTest = createMockPeopleResponse(totalPages = 2, results = peopleForRandomizedTest)
+    private val firstPageForRandomizedTest =
+        createMockPeopleResponse(totalPages = 2, results = peopleForRandomizedTest)
     private val secondPageForRandomizedTest = createMockPeopleResponse(
         totalPages = 2, results = listOf(
             createPeopleItemDto(id = 3, name = "Spike", profilePath = "path3"),
@@ -154,7 +169,8 @@ class PeopleRemoteDataSourceImplTest {
         totalPages = 1, results = peopleWithExtraData
     )
     private val firstPageWithDuplicateId = createMockPeopleResponse(
-        totalPages = 2, results = listOf(createPeopleItemDto(id = 1, name = "Tom", profilePath = "path1"))
+        totalPages = 2,
+        results = listOf(createPeopleItemDto(id = 1, name = "Tom", profilePath = "path1"))
     )
     private val secondPageWithDuplicateId = createMockPeopleResponse(
         totalPages = 2, results = peopleWithDuplicateId

--- a/repository/src/main/java/com/amsterdam/repository/datasource/remote/PeopleRemoteDataSource.kt
+++ b/repository/src/main/java/com/amsterdam/repository/datasource/remote/PeopleRemoteDataSource.kt
@@ -1,10 +1,8 @@
 package com.amsterdam.repository.datasource.remote
 
 import com.amsterdam.repository.dto.remote.RemotePeopleItemDto
-import com.amsterdam.repository.dto.remote.RemotePeopleResponse
 
 interface PeopleRemoteDataSource {
-    suspend fun getTrendingPeople(page: Int): RemotePeopleResponse
     suspend fun getRandomizedTrendingPeople(
         requiredNumber: Int,
     ): List<RemotePeopleItemDto>


### PR DESCRIPTION
## Description
The `getTrendingPeople` function in `PeopleRemoteDataSourceImpl` is now private as it's only used internally by `getRandomizedTrendingPeople`.

The corresponding function declaration has been removed from the `PeopleRemoteDataSource` interface.

Tests related to the public `getTrendingPeople` function have also been removed.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.