### PR TITLE
Fix/watch history screen bugs

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/NoDataContainer.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/NoDataContainer.kt
@@ -47,7 +47,8 @@ fun NoDataContainer(
         )
         if (title.isNotEmpty()) {
             Text(
-                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
+                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                    .alpha(.68f),
                 text = title,
                 style = AppTheme.textStyle.title.medium,
                 color = AppTheme.color.title,
@@ -55,6 +56,7 @@ fun NoDataContainer(
         }
         if (description.isNotEmpty()) {
             Text(
+                modifier = Modifier.alpha(.68f),
                 text = description,
                 style = AppTheme.textStyle.body.small,
                 color = AppTheme.color.body,

--- a/ui/src/main/java/com/amsterdam/ui/components/NoDataContainer.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/NoDataContainer.kt
@@ -29,7 +29,7 @@ fun NoDataContainer(
     modifier: Modifier = Modifier,
     title: String = "",
     description: String = "",
-    imageAlpha: Float = 1f,
+    imageAlpha: Float = .68f,
 ) {
     Column(
         modifier =

--- a/ui/src/main/java/com/amsterdam/ui/screens/watchHistory/WatchHistoryScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/watchHistory/WatchHistoryScreen.kt
@@ -1,6 +1,7 @@
 package com.amsterdam.ui.screens.watchHistory
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -98,7 +99,7 @@ fun WatchHistoryContent(
                 title = stringResource(R.string.watch_history),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 8.dp),
+                    .padding(vertical = 5.dp),
                 onNavigateBackClicked = interactionListener::onClickBack
             )
 

--- a/ui/src/main/java/com/amsterdam/ui/screens/watchHistory/WatchHistoryScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/watchHistory/WatchHistoryScreen.kt
@@ -1,7 +1,5 @@
 package com.amsterdam.ui.screens.watchHistory
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -27,20 +25,21 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.amsterdam.ui.R
 import com.amsterdam.designsystem.components.CenterOfScreenContainer
 import com.amsterdam.designsystem.components.LoadingContainer
 import com.amsterdam.designsystem.components.TabsLayout
+import com.amsterdam.ui.R
 import com.amsterdam.ui.R.drawable.no_saved_items
 import com.amsterdam.ui.R.string.no_items_here
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.components.NoDataContainer
 import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.components.appBar.DefaultAppBar
+import com.amsterdam.ui.screens.home.sections.AnimatedSectionVisibility
 import com.amsterdam.ui.screens.watchHistory.sections.SuccessMovieMediaItemsSection
 import com.amsterdam.ui.screens.watchHistory.sections.SuccessTvShowMediaItemsSection
-import com.amsterdam.ui.screens.home.sections.AnimatedSectionVisibility
 import com.amsterdam.viewmodel.shared.TabOption
 import com.amsterdam.viewmodel.watchHistory.WatchHistoryEffect
 import com.amsterdam.viewmodel.watchHistory.WatchHistoryInteractionListener
@@ -52,7 +51,9 @@ import kotlinx.coroutines.flow.collectLatest
 fun WatchHistoryScreen(viewModel: WatchHistoryViewModel = hiltViewModel()) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val navigationManager = LocalNavManager.current
+
     WatchHistoryContent(state, viewModel, viewModel::onClickTabOption)
+
     LaunchedEffect(Unit) {
         viewModel.effect.collectLatest { effect ->
             when (effect) {
@@ -78,10 +79,36 @@ fun WatchHistoryContent(
     interactionListener: WatchHistoryInteractionListener,
     onTabOptionClicked: (TabOption) -> Unit,
 ) {
-    val selectedMovies = state.movies.collectAsLazyPagingItems()
-    val selectedTvShows = state.tvShows.collectAsLazyPagingItems()
+    val moviesPaging =
+        state.movies.collectAsLazyPagingItems<WatchHistoryUiState.WatchHistoryMovieUiState>()
+    val tvShowsPaging =
+        state.tvShows.collectAsLazyPagingItems<WatchHistoryUiState.WatchHistoryTvShowUiState>()
 
     var headerHeight by remember { mutableStateOf(0.dp) }
+    var lastSelectedTab by remember { mutableStateOf(state.selectedTabOption) }
+
+    var moviesEmpty by remember { mutableStateOf<Boolean?>(null) }
+    var tvShowsEmpty by remember { mutableStateOf<Boolean?>(null) }
+    var moviesFirstLoadDone by remember { mutableStateOf(false) }
+    var tvShowsFirstLoadDone by remember { mutableStateOf(false) }
+
+    LaunchedEffect(moviesPaging.itemCount, moviesPaging.loadState.refresh) {
+        if (moviesPaging.loadState.refresh !is LoadState.Loading) {
+            moviesFirstLoadDone = true
+            if (moviesEmpty == null) {
+                moviesEmpty = moviesPaging.itemCount == 0
+            }
+        }
+    }
+
+    LaunchedEffect(tvShowsPaging.itemCount, tvShowsPaging.loadState.refresh) {
+        if (tvShowsPaging.loadState.refresh !is LoadState.Loading) {
+            tvShowsFirstLoadDone = true
+            if (tvShowsEmpty == null) {
+                tvShowsEmpty = tvShowsPaging.itemCount == 0
+            }
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -105,31 +132,66 @@ fun WatchHistoryContent(
 
             TabsLayout(
                 modifier = Modifier.fillMaxWidth(),
-                tabs =
-                    listOf(
-                        stringResource(R.string.movies),
-                        stringResource(R.string.tv_shows),
-                    ),
+                tabs = listOf(
+                    stringResource(R.string.movies),
+                    stringResource(R.string.tv_shows),
+                ),
                 selectedIndex = state.selectedTabOption.index,
-                onSelectTab = { index -> onTabOptionClicked(TabOption.entries[index]) },
+                onSelectTab = { index ->
+                    val newTab = TabOption.entries[index]
+                    if (newTab != lastSelectedTab) {
+                        lastSelectedTab = newTab
+                        onTabOptionClicked(newTab)
+                    }
+                },
             )
         }
 
-        AnimatedContent(state.selectedTabOption) { selectedTab ->
-            if (selectedTab == TabOption.MOVIES && selectedMovies.itemCount != 0) {
-                SuccessMovieMediaItemsSection(
-                    onMovieClicked = interactionListener::onClickMovieCard,
-                    selectedItems = selectedMovies
-                )
-            } else if (selectedTab == TabOption.TV_SHOWS && selectedTvShows.itemCount != 0) {
-                SuccessTvShowMediaItemsSection(
-                    onTvShowClicked = interactionListener::onClickTvShowCard,
-                    selectedItems = selectedTvShows
-                )
-            } else {
-                NoItemFoundContainer(
-                    headerHeight = headerHeight,
-                )
+        Box(modifier = Modifier.fillMaxSize()) {
+            AnimatedSectionVisibility(visible = state.selectedTabOption == TabOption.MOVIES) {
+                when {
+                    !moviesFirstLoadDone &&
+                            moviesPaging.loadState.refresh is LoadState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) { LoadingContainer() }
+                    }
+
+                    moviesPaging.itemCount > 0 -> {
+                        SuccessMovieMediaItemsSection(
+                            onMovieClicked = interactionListener::onClickMovieCard,
+                            selectedItems = moviesPaging
+                        )
+                    }
+
+                    moviesEmpty == true -> {
+                        NoItemFoundContainer(headerHeight = headerHeight)
+                    }
+                }
+            }
+
+            AnimatedSectionVisibility(visible = state.selectedTabOption == TabOption.TV_SHOWS) {
+                when {
+                    !tvShowsFirstLoadDone &&
+                            tvShowsPaging.loadState.refresh is LoadState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) { LoadingContainer() }
+                    }
+
+                    tvShowsPaging.itemCount > 0 -> {
+                        SuccessTvShowMediaItemsSection(
+                            onTvShowClicked = interactionListener::onClickTvShowCard,
+                            selectedItems = tvShowsPaging
+                        )
+                    }
+
+                    tvShowsEmpty == true -> {
+                        NoItemFoundContainer(headerHeight = headerHeight)
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.
- fixed padding issues and colors
- fixed different states reloading which leads to problem in the ui and user experience
---

## Changes Made
List the changes introduced in this pull request:

- **Removed duplicate imports** (`R`, `AnimatedSectionVisibility`).
- **Adjusted `NoDataContainer`**:
  - Added `alpha(.68f)` to `title` and `description` text.
  - Duplicate `imageAlpha` param fixed.
- **WatchHistoryScreen**:
  - Simplified call to `WatchHistoryContent`.
- **WatchHistoryContent**:
  - Replaced `selectedMovies` / `selectedTvShows` with strongly typed `moviesPaging` & `tvShowsPaging`.
  - Added state tracking:
    - `moviesEmpty`, `tvShowsEmpty`
    - `moviesFirstLoadDone`, `tvShowsFirstLoadDone`
    - `lastSelectedTab`
  - Added `LaunchedEffect` blocks to track empty lists & load completion.
  - Adjusted `AppBar` padding (`8.dp → 5.dp`).
  - Tabs now prevent reloading on same tab click.
- **UI Rendering**:
  - Replaced `AnimatedContent` with `AnimatedSectionVisibility` for smoother tab switching.
  - Show loading state only on **first load**.
  - Show `NoItemFoundContainer` only after confirming list is empty.
---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.