### PR TITLE
fix: game crash and remove unnecessary mapping

### DIFF
--- a/domain/src/main/java/com/amsterdam/domain/useCase/game/GetAvailableGamesUseCase.kt
+++ b/domain/src/main/java/com/amsterdam/domain/useCase/game/GetAvailableGamesUseCase.kt
@@ -31,8 +31,8 @@ class GetAvailableGamesUseCase {
         val games = listOf(
             Game(gameType = Game.GameType.GUESS_CHARACTER, requiredPoints = 0),
             Game(gameType = Game.GameType.GUESS_MOVIE_BY_POSTER, requiredPoints = 0),
-            Game(gameType = Game.GameType.GUESS_MOVIE_BY_RELEASE, requiredPoints = 400),
-            Game(gameType = Game.GameType.GUESS_MOVIE_BY_GENRE, requiredPoints = 400)
+            Game(gameType = Game.GameType.GUESS_RELEASE_YEAR, requiredPoints = 400),
+            Game(gameType = Game.GameType.GUESS_GENRE, requiredPoints = 400)
         )
         return AvailableGames(games, defaultLevels)
     }

--- a/domain/src/test/java/com/amsterdam/domain/useCase/game/GetAvailableGamesUseCaseTest.kt
+++ b/domain/src/test/java/com/amsterdam/domain/useCase/game/GetAvailableGamesUseCaseTest.kt
@@ -19,8 +19,8 @@ class GetAvailableGamesUseCaseTest {
         games = listOf(
             Game(gameType = Game.GameType.GUESS_CHARACTER, requiredPoints = 0),
             Game(gameType = Game.GameType.GUESS_MOVIE_BY_POSTER, requiredPoints = 0),
-            Game(gameType = Game.GameType.GUESS_MOVIE_BY_RELEASE, requiredPoints = 400),
-            Game(gameType = Game.GameType.GUESS_MOVIE_BY_GENRE, requiredPoints = 400)
+            Game(gameType = Game.GameType.GUESS_RELEASE_YEAR, requiredPoints = 400),
+            Game(gameType = Game.GameType.GUESS_GENRE, requiredPoints = 400)
         ),
         difficultyLevels = listOf(
             GameDifficulty(5, 45, 5, GameDifficulty.DifficultyType.EASY),

--- a/entity/src/main/java/com/amsterdam/entity/Game.kt
+++ b/entity/src/main/java/com/amsterdam/entity/Game.kt
@@ -4,10 +4,10 @@ data class Game(
     val gameType: GameType,
     val requiredPoints: Int
 ) {
-    enum class GameType() {
+    enum class GameType {
         GUESS_CHARACTER,
         GUESS_MOVIE_BY_POSTER,
-        GUESS_MOVIE_BY_RELEASE,
-        GUESS_MOVIE_BY_GENRE
+        GUESS_RELEASE_YEAR,
+        GUESS_GENRE
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/gameResult/ResultScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/gameResult/ResultScreen.kt
@@ -26,6 +26,7 @@ import com.amsterdam.designsystem.components.Scaffold
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.designsystem.components.buttons.OutlinedButton
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
+import com.amsterdam.entity.Game
 import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.screens.gameResult.component.CompletionCard
@@ -50,19 +51,19 @@ fun ResultScreen(
             when (effect) {
                 is ResultSideEffect.NavigateToGame -> {
                     when (effect.gameType) {
-                        ResultSideEffect.GameTypeUi.GUESS_MOVIE_BY_POSTER -> {
+                        Game.GameType.GUESS_MOVIE_BY_POSTER -> {
                             navigationManager.toGuessMovieByPosterGame(effect.difficultyType)
                         }
 
-                        ResultSideEffect.GameTypeUi.GUESS_RELEASE_YEAR -> {
+                        Game.GameType.GUESS_RELEASE_YEAR -> {
                             navigationManager.toGuessReleaseYearGame(effect.difficultyType)
                         }
 
-                        ResultSideEffect.GameTypeUi.GUESS_CHARACTER -> {
+                        Game.GameType.GUESS_CHARACTER -> {
                             navigationManager.toGuessCharacter(effect.difficultyType)
                         }
 
-                        ResultSideEffect.GameTypeUi.GUESS_GENRE -> {
+                        Game.GameType.GUESS_GENRE -> {
                             navigationManager.toGenreGame(effect.difficultyType)
                         }
                     }

--- a/ui/src/main/java/com/amsterdam/ui/screens/letsPlay/GameTypeData.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/letsPlay/GameTypeData.kt
@@ -3,9 +3,9 @@ package com.amsterdam.ui.screens.letsPlay
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.amsterdam.designsystem.theme.AppTheme
+import com.amsterdam.entity.Game
 import com.amsterdam.ui.R
 import com.amsterdam.ui.screens.letsPlay.component.GameCardImageContentType
-import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameUiState.GameTypeUiState
 
 data class GameTypeData(
     val title: Int,
@@ -16,9 +16,9 @@ data class GameTypeData(
     val gameCardImageContentType: GameCardImageContentType,
 )
 @Composable
-fun GameTypeUiState.getGameTypeData(): GameTypeData {
+fun Game.GameType.getGameTypeData(): GameTypeData {
     return when (this) {
-        GameTypeUiState.GUESS_CHARACTER -> GameTypeData(
+        Game.GameType.GUESS_CHARACTER -> GameTypeData(
             R.string.guess_character_game_title,
             R.string.guess_character_game_description,
             AppTheme.color.primaryVariant,
@@ -27,7 +27,7 @@ fun GameTypeUiState.getGameTypeData(): GameTypeData {
             GameCardImageContentType.FUN_CLOWN,
         )
 
-        GameTypeUiState.GUESS_MOVIE_BY_POSTER -> GameTypeData(
+        Game.GameType.GUESS_MOVIE_BY_POSTER -> GameTypeData(
             R.string.guess_movie_game_title,
             R.string.guess_movie_game_description,
             AppTheme.color.blueCard,
@@ -35,7 +35,7 @@ fun GameTypeUiState.getGameTypeData(): GameTypeData {
             AppTheme.color.blueAccent,
             GameCardImageContentType.MANY_POSTERS,
         )
-        GameTypeUiState.GUESS_MOVIE_BY_RELEASE -> GameTypeData(
+        Game.GameType.GUESS_RELEASE_YEAR -> GameTypeData(
             R.string.release_game_title,
             R.string.release_game_description,
             AppTheme.color.navyCard,
@@ -44,7 +44,7 @@ fun GameTypeUiState.getGameTypeData(): GameTypeData {
             GameCardImageContentType.CALENDER,
         )
 
-        GameTypeUiState.GUESS_MOVIE_BY_GENRE -> GameTypeData(
+        Game.GameType.GUESS_GENRE -> GameTypeData(
             R.string.genre_game_title,
             R.string.genre_game_description,
             AppTheme.color.yellowCard,

--- a/ui/src/main/java/com/amsterdam/ui/screens/letsPlay/LetsPlayScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/letsPlay/LetsPlayScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.amsterdam.designsystem.theme.AppTheme
+import com.amsterdam.entity.Game
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.application.LocalScaffoldBottomPadding
 import com.amsterdam.ui.screens.letsPlay.component.GameCard
@@ -36,7 +37,6 @@ import com.amsterdam.viewmodel.letsPlay.LetsPlayEffect
 import com.amsterdam.viewmodel.letsPlay.LetsPlayInteractionListener
 import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState
 import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameDifficultyUiState
-import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameUiState.GameTypeUiState
 import com.amsterdam.viewmodel.letsPlay.LetsPlayViewModel
 
 @Composable
@@ -98,14 +98,14 @@ private fun LetsPlayScreenContent(
             }
 
             this.items(state.games) {
-                val gameCardData = it.gameTypeUiState.getGameTypeData()
+                val gameCardData = it.gameType.getGameTypeData()
                 GameCard(
                     title = stringResource(gameCardData.title),
                     description = stringResource(gameCardData.description),
                     containerColor = gameCardData.containerColor,
                     borderColors = gameCardData.borderColors,
                     shadowColor = gameCardData.shadowColor,
-                    onClick = { interactionListener.onClickGameCard(it.gameTypeUiState) },
+                    onClick = { interactionListener.onClickGameCard(it.gameType) },
                     gameCardImageContentType = gameCardData.gameCardImageContentType,
                     isPlayable = state.totalUserPoint >= it.requiredPoints,
                     unlockPrice = "${it.requiredPoints}"
@@ -116,7 +116,7 @@ private fun LetsPlayScreenContent(
 
 
     AnimatedVisibility(
-        visible = state.selectedGameTypeUiState != null,
+        visible = state.selectedGameType != null,
         modifier = Modifier.align(Alignment.Center),
         enter = fadeIn(animationSpec = tween(600)),
         exit = fadeOut(animationSpec = tween(0))
@@ -141,7 +141,7 @@ private fun LetsPlayScreenPreview() {
         state = LetsPlayUiState(), interactionListener = object : LetsPlayInteractionListener {
             override fun onSelectDifficultyLevel(difficultyLevel: GameDifficultyUiState) {}
             override fun onClickCloseDifficultyLevelDialog() {}
-            override fun onClickGameCard(gameTypeUiState: GameTypeUiState) {}
+            override fun onClickGameCard(gameType: Game.GameType) {}
             override fun onClickStartGame() {}
         })
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/GameResultViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/GameResultViewModel.kt
@@ -4,7 +4,6 @@ import com.amsterdam.domain.useCase.game.GetCollectedPointsUseCase
 import com.amsterdam.domain.useCase.game.GetSpentSecondsUseCase
 import com.amsterdam.entity.Game.GameType
 import com.amsterdam.entity.GameDifficulty.DifficultyType
-import com.amsterdam.viewmodel.gameResult.ResultSideEffect.GameTypeUi
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -27,20 +26,17 @@ class GameResultViewModel @Inject constructor(
 
     init {
         updateState {
-            it.copy(points = getCollectedPointsUseCase(gameSessionId), timeInSeconds = getSpentSecondsUseCase(gameSessionId))
+            it.copy(
+                points = getCollectedPointsUseCase(gameSessionId),
+                timeInSeconds = getSpentSecondsUseCase(gameSessionId)
+            )
         }
     }
 
     override fun onClickPlayAgain() {
-        val gameTypeUi = when(gameType) {
-            GameType.GUESS_CHARACTER -> GameTypeUi.GUESS_CHARACTER
-            GameType.GUESS_MOVIE_BY_POSTER -> GameTypeUi.GUESS_MOVIE_BY_POSTER
-            GameType.GUESS_MOVIE_BY_RELEASE -> GameTypeUi.GUESS_RELEASE_YEAR
-            GameType.GUESS_MOVIE_BY_GENRE -> GameTypeUi.GUESS_GENRE
-        }
         sendNewNavigationEffect(
             ResultSideEffect.NavigateToGame(
-                gameTypeUi,
+                gameType,
                 difficultyType.name
             )
         )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/ResultSideEffect.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/ResultSideEffect.kt
@@ -1,19 +1,13 @@
 package com.amsterdam.viewmodel.gameResult
 
+import com.amsterdam.entity.Game
 import com.amsterdam.viewmodel.shared.BaseViewModel
 
 sealed interface ResultSideEffect : BaseViewModel.BaseUiEffect {
     data class NavigateToGame(
-        val gameType : GameTypeUi,
+        val gameType : Game.GameType,
        val difficultyType : String
     ) : ResultSideEffect
 
     data object NavigateBackToMenu : ResultSideEffect
-
-    enum class GameTypeUi {
-        GUESS_MOVIE_BY_POSTER,
-        GUESS_RELEASE_YEAR,
-        GUESS_CHARACTER,
-        GUESS_GENRE
-    }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
@@ -3,19 +3,19 @@ package com.amsterdam.viewmodel.guessCharacterGame
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.exceptions.NotEnoughPointsException
-import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import com.amsterdam.domain.useCase.game.AddPointsToGameUseCase
 import com.amsterdam.domain.useCase.game.AddSecondToGameTimeUseCase
 import com.amsterdam.domain.useCase.game.CreateGameSessionIdUseCase
 import com.amsterdam.domain.useCase.game.character.GuessCharacterGameUseCase
 import com.amsterdam.domain.utils.AnswerResult
 import com.amsterdam.domain.utils.GameQuestion
+import com.amsterdam.entity.Game
 import com.amsterdam.entity.GameDifficulty.DifficultyType
 import com.amsterdam.viewmodel.gameResult.ResultScreenData
-import com.amsterdam.viewmodel.gameResult.ResultSideEffect
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.sharedGame.TimerUiState
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
+import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,7 +29,7 @@ class GuessCharacterGameViewModel @Inject constructor(
     private val timerHandler: TimerHandler,
     private val dispatcherProvider: DispatcherProvider,
     args: GuessCharacterGameArgs
-    ) : BaseViewModel<GuessCharacterUiState, GuessCharacterGameEffect>(
+) : BaseViewModel<GuessCharacterUiState, GuessCharacterGameEffect>(
     GuessCharacterUiState(),
     dispatcherProvider
 ), GuessCharacterInteractionListener {
@@ -69,7 +69,7 @@ class GuessCharacterGameViewModel @Inject constructor(
                 currentQuestion.questionTimeSeconds,
                 onTimerFinish = ::onMoveToNextQuestion
             )
-                .collect(::onTimerUpdate)
+                    .collect(::onTimerUpdate)
         }
     }
 
@@ -141,7 +141,7 @@ class GuessCharacterGameViewModel @Inject constructor(
                 selectedAnswerIndex = selectedAnswerIndex
             )
         }
-        addPointsToGameUseCase(answerResult.earnedPoints,state.value.gameSessionId)
+        addPointsToGameUseCase(answerResult.earnedPoints, state.value.gameSessionId)
     }
 
     private fun onSubmitTheAnswerComplete() {
@@ -185,7 +185,7 @@ class GuessCharacterGameViewModel @Inject constructor(
     private fun handleGameFinished() {
         val resultData = ResultScreenData(
             difficulty = difficultyType.name,
-            gameType = ResultSideEffect.GameTypeUi.GUESS_CHARACTER.name,
+            gameType = Game.GameType.GUESS_CHARACTER.name,
             gameSessionId = state.value.gameSessionId
         )
         sendNewNavigationEffect(

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
@@ -3,19 +3,19 @@ package com.amsterdam.viewmodel.guessMovieByPosterGame
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.exceptions.NotEnoughPointsException
-import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import com.amsterdam.domain.useCase.game.AddPointsToGameUseCase
 import com.amsterdam.domain.useCase.game.AddSecondToGameTimeUseCase
 import com.amsterdam.domain.useCase.game.CreateGameSessionIdUseCase
 import com.amsterdam.domain.useCase.game.guessByPoster.GuessMovieByPosterGameUseCase
 import com.amsterdam.domain.utils.AnswerResult
 import com.amsterdam.domain.utils.GameQuestion
+import com.amsterdam.entity.Game
 import com.amsterdam.entity.GameDifficulty
 import com.amsterdam.viewmodel.gameResult.ResultScreenData
-import com.amsterdam.viewmodel.gameResult.ResultSideEffect
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.sharedGame.TimerUiState
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
+import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -69,7 +69,7 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
                 currentQuestion.questionTimeSeconds,
                 onTimerFinish = ::onMoveToNextQuestion
             )
-                .collect(::onTimerUpdate)
+                    .collect(::onTimerUpdate)
         }
     }
 
@@ -179,7 +179,7 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
         } else {
             val resultData = ResultScreenData(
                 difficulty = difficultyType.name,
-                gameType = ResultSideEffect.GameTypeUi.GUESS_MOVIE_BY_POSTER.name,
+                gameType = Game.GameType.GUESS_MOVIE_BY_POSTER.name,
                 gameSessionId = state.value.gameSessionId
             )
             sendNewNavigationEffect(

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearGameViewModel.kt
@@ -3,19 +3,19 @@ package com.amsterdam.viewmodel.guessReleseDateGame
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.exceptions.NotEnoughPointsException
-import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import com.amsterdam.domain.useCase.game.AddPointsToGameUseCase
 import com.amsterdam.domain.useCase.game.AddSecondToGameTimeUseCase
 import com.amsterdam.domain.useCase.game.CreateGameSessionIdUseCase
 import com.amsterdam.domain.useCase.game.releaseYear.GuessReleaseYearGameUseCase
 import com.amsterdam.domain.utils.AnswerResult
 import com.amsterdam.domain.utils.GameQuestion
+import com.amsterdam.entity.Game
 import com.amsterdam.entity.GameDifficulty.DifficultyType
 import com.amsterdam.viewmodel.gameResult.ResultScreenData
-import com.amsterdam.viewmodel.gameResult.ResultSideEffect
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.sharedGame.TimerUiState
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
+import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,7 +29,7 @@ class GuessReleaseYearGameViewModel @Inject constructor(
     private val timerHandler: TimerHandler,
     private val dispatcherProvider: DispatcherProvider,
     args: GuessReleaseYearGameArgs
-    ) : BaseViewModel<GuessReleaseYearUiState, GuessReleaseYearGameEffect>(
+) : BaseViewModel<GuessReleaseYearUiState, GuessReleaseYearGameEffect>(
     GuessReleaseYearUiState(),
     dispatcherProvider
 ), GuessReleaseYearInteractionListener {
@@ -69,7 +69,7 @@ class GuessReleaseYearGameViewModel @Inject constructor(
                 currentQuestion.questionTimeSeconds,
                 onTimerFinish = ::onMoveToNextQuestion
             )
-                .collect(::onTimerUpdate)
+                    .collect(::onTimerUpdate)
         }
     }
 
@@ -162,7 +162,7 @@ class GuessReleaseYearGameViewModel @Inject constructor(
         } else {
             val resultData = ResultScreenData(
                 difficulty = difficultyType.name,
-                gameType = ResultSideEffect.GameTypeUi.GUESS_RELEASE_YEAR.name,
+                gameType = Game.GameType.GUESS_RELEASE_YEAR.name,
                 gameSessionId = state.value.gameSessionId
             )
             sendNewNavigationEffect(

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GuessGenreViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GuessGenreViewModel.kt
@@ -3,13 +3,13 @@ package com.amsterdam.viewmodel.guessWhichGenre
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.domain.exceptions.NotEnoughPointsException
-import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import com.amsterdam.domain.useCase.game.AddPointsToGameUseCase
 import com.amsterdam.domain.useCase.game.AddSecondToGameTimeUseCase
 import com.amsterdam.domain.useCase.game.CreateGameSessionIdUseCase
 import com.amsterdam.domain.useCase.game.whichGenre.GuessMovieGenreUseCase
 import com.amsterdam.domain.utils.AnswerResult
 import com.amsterdam.domain.utils.GameQuestion
+import com.amsterdam.entity.Game
 import com.amsterdam.entity.GameDifficulty.DifficultyType
 import com.amsterdam.entity.category.MovieGenre
 import com.amsterdam.viewmodel.gameResult.ResultScreenData
@@ -17,6 +17,7 @@ import com.amsterdam.viewmodel.gameResult.ResultSideEffect
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.sharedGame.TimerUiState
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
+import com.amsterdam.viewmodel.utils.timer.TimerHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -71,7 +72,7 @@ class GuessGenreViewModel @Inject constructor(
                 currentQuestion.questionTime,
                 onTimerFinish = ::onMoveToNextQuestion
             )
-                .collect(::onTimerUpdate)
+                    .collect(::onTimerUpdate)
         }
     }
 
@@ -171,10 +172,10 @@ class GuessGenreViewModel @Inject constructor(
         } else {
             val resultData = ResultScreenData(
                 difficulty = difficultyType.name,
-                gameType = ResultSideEffect.GameTypeUi.GUESS_GENRE.name,
+                gameType = Game.GameType.GUESS_GENRE.name,
                 gameSessionId = state.value.gameSessionId
             )
-            sendNewEffect(GenreGameEffect.GameOver(resultData))
+            sendNewNavigationEffect(GenreGameEffect.GameOver(resultData))
         }
     }
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayInteractionListener.kt
@@ -1,11 +1,11 @@
 package com.amsterdam.viewmodel.letsPlay
 
+import com.amsterdam.entity.Game
 import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameDifficultyUiState
-import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameUiState.GameTypeUiState
 
 interface LetsPlayInteractionListener {
     fun onSelectDifficultyLevel(difficultyLevel: GameDifficultyUiState)
     fun onClickCloseDifficultyLevelDialog()
-    fun onClickGameCard(gameTypeUiState : GameTypeUiState)
+    fun onClickGameCard(gameType : Game.GameType)
     fun onClickStartGame()
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayUiState.kt
@@ -1,11 +1,11 @@
 package com.amsterdam.viewmodel.letsPlay
 
-import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameUiState.GameTypeUiState
+import com.amsterdam.entity.Game
 
 data class LetsPlayUiState(
     val difficulties: List<GameDifficultyUiState> = emptyList(),
     val games: List<GameUiState> = emptyList(),
-    val selectedGameTypeUiState: GameTypeUiState? = null,
+    val selectedGameType: Game.GameType? = null,
     val selectedDifficultyLevel: GameDifficultyUiState? = null,
     val isStartGameButtonEnable: Boolean = false,
     val totalUserPoint: Int = 0
@@ -24,12 +24,5 @@ data class LetsPlayUiState(
         }
     }
 
-    data class GameUiState(val gameTypeUiState: GameTypeUiState, val requiredPoints: Int) {
-        enum class GameTypeUiState {
-            GUESS_CHARACTER,
-            GUESS_MOVIE_BY_POSTER,
-            GUESS_MOVIE_BY_RELEASE,
-            GUESS_MOVIE_BY_GENRE
-        }
-    }
+    data class GameUiState(val gameType: Game.GameType, val requiredPoints: Int)
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayUiStateMapper.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayUiStateMapper.kt
@@ -2,12 +2,10 @@ package com.amsterdam.viewmodel.letsPlay
 
 import com.amsterdam.domain.useCase.game.GetAvailableGamesUseCase.AvailableGames
 import com.amsterdam.entity.Game
-import com.amsterdam.entity.Game.GameType
 import com.amsterdam.entity.GameDifficulty
 import com.amsterdam.entity.GameDifficulty.DifficultyType
 import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameDifficultyUiState
 import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameDifficultyUiState.DifficultyLevelUiState
-import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameUiState.GameTypeUiState
 
 fun AvailableGames.toLetsPlayUiState() = LetsPlayUiState(
     difficulties = difficultyLevels.toGameDifficultiesUiState(),
@@ -18,17 +16,8 @@ fun List<Game>.toGamesUiState() = map { it.toGameUiState() }
 
 fun Game.toGameUiState() = LetsPlayUiState.GameUiState(
     requiredPoints = requiredPoints,
-    gameTypeUiState = gameType.toGameTypeUiState()
+    gameType = gameType
 )
-
-fun GameType.toGameTypeUiState(): GameTypeUiState {
-    return when (this) {
-        GameType.GUESS_CHARACTER -> GameTypeUiState.GUESS_CHARACTER
-        GameType.GUESS_MOVIE_BY_POSTER -> GameTypeUiState.GUESS_MOVIE_BY_POSTER
-        GameType.GUESS_MOVIE_BY_RELEASE -> GameTypeUiState.GUESS_MOVIE_BY_RELEASE
-        GameType.GUESS_MOVIE_BY_GENRE -> GameTypeUiState.GUESS_MOVIE_BY_GENRE
-    }
-}
 
 fun List<GameDifficulty>.toGameDifficultiesUiState() = map { it.toGameDifficultyUiState() }
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/letsPlay/LetsPlayViewModel.kt
@@ -3,8 +3,8 @@ package com.amsterdam.viewmodel.letsPlay
 import androidx.lifecycle.viewModelScope
 import com.amsterdam.domain.useCase.common.GetTotalUserPointsUseCase
 import com.amsterdam.domain.useCase.game.GetAvailableGamesUseCase
+import com.amsterdam.entity.Game
 import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameDifficultyUiState
-import com.amsterdam.viewmodel.letsPlay.LetsPlayUiState.GameUiState.GameTypeUiState
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -52,17 +52,17 @@ class LetsPlayViewModel @Inject constructor(
     override fun onClickCloseDifficultyLevelDialog() {
         updateState {
             it.copy(
-                selectedGameTypeUiState = null,
+                selectedGameType = null,
                 selectedDifficultyLevel = null,
                 isStartGameButtonEnable = false
             )
         }
     }
 
-    override fun onClickGameCard(gameTypeUiState: GameTypeUiState) {
+    override fun onClickGameCard(gameType: Game.GameType) {
         updateState {
             it.copy(
-                selectedGameTypeUiState = gameTypeUiState
+                selectedGameType = gameType
             )
         }
     }
@@ -70,17 +70,17 @@ class LetsPlayViewModel @Inject constructor(
     override fun onClickStartGame() {
         val difficultyLevelName =
             state.value.selectedDifficultyLevel?.difficultyLevel?.name ?: return
-        val navigateEffect = when (state.value.selectedGameTypeUiState) {
-            GameTypeUiState.GUESS_CHARACTER ->
+        val navigateEffect = when (state.value.selectedGameType) {
+            Game.GameType.GUESS_CHARACTER ->
                 LetsPlayEffect.NavigateToGuessCharacterScreen(difficultyLevelName)
 
-            GameTypeUiState.GUESS_MOVIE_BY_POSTER ->
+            Game.GameType.GUESS_MOVIE_BY_POSTER ->
                 LetsPlayEffect.NavigateToGuessMovieByPosterScreen(difficultyLevelName)
 
-            GameTypeUiState.GUESS_MOVIE_BY_RELEASE ->
+            Game.GameType.GUESS_RELEASE_YEAR ->
                 LetsPlayEffect.NavigateToGuessMovieByReleaseScreen(difficultyLevelName)
 
-            GameTypeUiState.GUESS_MOVIE_BY_GENRE ->
+            Game.GameType.GUESS_GENRE ->
                 LetsPlayEffect.NavigateToGuessMovieByGenreScreen(difficultyLevelName)
 
             null -> {
@@ -89,7 +89,7 @@ class LetsPlayViewModel @Inject constructor(
         }
         updateState {
             it.copy(
-                selectedGameTypeUiState = null,
+                selectedGameType = null,
                 selectedDifficultyLevel = null,
                 isStartGameButtonEnable = false
             )

--- a/viewModel/src/test/java/com/amsterdam/viewmodel/letsPlay/LetsPlayViewModelTest.kt
+++ b/viewModel/src/test/java/com/amsterdam/viewmodel/letsPlay/LetsPlayViewModelTest.kt
@@ -54,13 +54,14 @@ class LetsPlayViewModelTest {
     }
 
     @Test
-    fun `init should correctly map and update state with available games and difficulties`() = runTest {
-        viewModel
-        advanceUntilIdle()
+    fun `init should correctly map and update state with available games and difficulties`() =
+        runTest {
+            viewModel
+            advanceUntilIdle()
 
-        assertThat(viewModel.state.value.games).isEqualTo(testGamesUiState)
-        assertThat(viewModel.state.value.difficulties).isEqualTo(testDifficultiesUiState)
-    }
+            assertThat(viewModel.state.value.games).isEqualTo(testGamesUiState)
+            assertThat(viewModel.state.value.difficulties).isEqualTo(testDifficultiesUiState)
+        }
 
     @Test
     fun `init should handle exception from getTotalUserPointsUseCase`() = runTest {
@@ -74,96 +75,106 @@ class LetsPlayViewModelTest {
 
     @Test
     fun `onClickGameCard should update state with the selected game type`() = runTest {
-        val selectedGameType = GameUiState.GameTypeUiState.GUESS_MOVIE_BY_POSTER
+        val selectedGameType = Game.GameType.GUESS_MOVIE_BY_POSTER
 
         viewModel.onClickGameCard(selectedGameType)
         advanceUntilIdle()
 
-        assertThat(viewModel.state.value.selectedGameTypeUiState).isEqualTo(selectedGameType)
+        assertThat(viewModel.state.value.selectedGameType).isEqualTo(selectedGameType)
     }
 
     @Test
-    fun `onSelectDifficultyLevel should update state with selected difficulty and enable start button`() = runTest {
-        val selectedDifficulty = hardDifficulty
+    fun `onSelectDifficultyLevel should update state with selected difficulty and enable start button`() =
+        runTest {
+            val selectedDifficulty = hardDifficulty
 
-        viewModel.onSelectDifficultyLevel(selectedDifficulty)
-        advanceUntilIdle()
+            viewModel.onSelectDifficultyLevel(selectedDifficulty)
+            advanceUntilIdle()
 
-        assertThat(viewModel.state.value.selectedDifficultyLevel).isEqualTo(selectedDifficulty)
-        assertThat(viewModel.state.value.isStartGameButtonEnable).isTrue()
-    }
-
-    @Test
-    fun `onClickCloseDifficultyLevelDialog should reset selections and disable start button`() = runTest {
-        viewModel.onClickGameCard(GameUiState.GameTypeUiState.GUESS_CHARACTER)
-        viewModel.onSelectDifficultyLevel(easyDifficulty)
-        advanceUntilIdle()
-
-        viewModel.onClickCloseDifficultyLevelDialog()
-        advanceUntilIdle()
-
-        assertThat(viewModel.state.value.selectedGameTypeUiState).isNull()
-        assertThat(viewModel.state.value.selectedDifficultyLevel).isNull()
-        assertThat(viewModel.state.value.isStartGameButtonEnable).isFalse()
-    }
-
-    @Test
-    fun `onClickStartGame should send NavigateToGuessCharacterScreen effect when selected`() = runTest {
-        viewModel.onClickGameCard(GameUiState.GameTypeUiState.GUESS_CHARACTER)
-        viewModel.onSelectDifficultyLevel(mediumDifficulty)
-        advanceUntilIdle()
-
-        viewModel.effect.test {
-            viewModel.onClickStartGame()
-            val expectedEffect = LetsPlayEffect.NavigateToGuessCharacterScreen(mediumDifficulty.difficultyLevel.name)
-            assertThat(awaitItem()).isEqualTo(expectedEffect)
+            assertThat(viewModel.state.value.selectedDifficultyLevel).isEqualTo(selectedDifficulty)
+            assertThat(viewModel.state.value.isStartGameButtonEnable).isTrue()
         }
-    }
 
     @Test
-    fun `onClickStartGame should send NavigateToGuessMovieByReleaseScreen effect when selected`() = runTest {
-        viewModel.onClickGameCard(GameUiState.GameTypeUiState.GUESS_MOVIE_BY_RELEASE)
-        viewModel.onSelectDifficultyLevel(hardDifficulty)
-        advanceUntilIdle()
+    fun `onClickCloseDifficultyLevelDialog should reset selections and disable start button`() =
+        runTest {
+            viewModel.onClickGameCard(Game.GameType.GUESS_CHARACTER)
+            viewModel.onSelectDifficultyLevel(easyDifficulty)
+            advanceUntilIdle()
 
-        viewModel.effect.test {
-            viewModel.onClickStartGame()
-            val expectedEffect = LetsPlayEffect.NavigateToGuessMovieByReleaseScreen(hardDifficulty.difficultyLevel.name)
-            assertThat(awaitItem()).isEqualTo(expectedEffect)
+            viewModel.onClickCloseDifficultyLevelDialog()
+            advanceUntilIdle()
+
+            assertThat(viewModel.state.value.selectedGameType).isNull()
+            assertThat(viewModel.state.value.selectedDifficultyLevel).isNull()
+            assertThat(viewModel.state.value.isStartGameButtonEnable).isFalse()
         }
-    }
 
     @Test
-    fun `onClickStartGame should send NavigateToGuessMovieByPosterScreen effect when selected`() = runTest {
-        viewModel.onClickGameCard(GameUiState.GameTypeUiState.GUESS_MOVIE_BY_POSTER)
+    fun `onClickStartGame should send NavigateToGuessCharacterScreen effect when selected`() =
+        runTest {
+            viewModel.onClickGameCard(Game.GameType.GUESS_CHARACTER)
+            viewModel.onSelectDifficultyLevel(mediumDifficulty)
+            advanceUntilIdle()
 
-        viewModel.onSelectDifficultyLevel(easyDifficulty)
-        advanceUntilIdle()
-
-        viewModel.effect.test {
-            viewModel.onClickStartGame()
-            val expectedEffect = LetsPlayEffect.NavigateToGuessMovieByPosterScreen(easyDifficulty.difficultyLevel.name)
-            assertThat(awaitItem()).isEqualTo(expectedEffect)
+            viewModel.effect.test {
+                viewModel.onClickStartGame()
+                val expectedEffect =
+                    LetsPlayEffect.NavigateToGuessCharacterScreen(mediumDifficulty.difficultyLevel.name)
+                assertThat(awaitItem()).isEqualTo(expectedEffect)
+            }
         }
-    }
 
     @Test
-    fun `onClickStartGame should send NavigateToGuessMovieByGenreScreen effect when selected`() = runTest {
-        viewModel.onClickGameCard(GameUiState.GameTypeUiState.GUESS_MOVIE_BY_GENRE)
+    fun `onClickStartGame should send NavigateToGuessMovieByReleaseScreen effect when selected`() =
+        runTest {
+            viewModel.onClickGameCard(Game.GameType.GUESS_RELEASE_YEAR)
+            viewModel.onSelectDifficultyLevel(hardDifficulty)
+            advanceUntilIdle()
 
-        viewModel.onSelectDifficultyLevel(mediumDifficulty)
-        advanceUntilIdle()
-
-        viewModel.effect.test {
-            viewModel.onClickStartGame()
-            val expectedEffect = LetsPlayEffect.NavigateToGuessMovieByGenreScreen(mediumDifficulty.difficultyLevel.name)
-            assertThat(awaitItem()).isEqualTo(expectedEffect)
+            viewModel.effect.test {
+                viewModel.onClickStartGame()
+                val expectedEffect =
+                    LetsPlayEffect.NavigateToGuessMovieByReleaseScreen(hardDifficulty.difficultyLevel.name)
+                assertThat(awaitItem()).isEqualTo(expectedEffect)
+            }
         }
-    }
+
+    @Test
+    fun `onClickStartGame should send NavigateToGuessMovieByPosterScreen effect when selected`() =
+        runTest {
+            viewModel.onClickGameCard(Game.GameType.GUESS_MOVIE_BY_POSTER)
+
+            viewModel.onSelectDifficultyLevel(easyDifficulty)
+            advanceUntilIdle()
+
+            viewModel.effect.test {
+                viewModel.onClickStartGame()
+                val expectedEffect =
+                    LetsPlayEffect.NavigateToGuessMovieByPosterScreen(easyDifficulty.difficultyLevel.name)
+                assertThat(awaitItem()).isEqualTo(expectedEffect)
+            }
+        }
+
+    @Test
+    fun `onClickStartGame should send NavigateToGuessMovieByGenreScreen effect when selected`() =
+        runTest {
+            viewModel.onClickGameCard(Game.GameType.GUESS_GENRE)
+
+            viewModel.onSelectDifficultyLevel(mediumDifficulty)
+            advanceUntilIdle()
+
+            viewModel.effect.test {
+                viewModel.onClickStartGame()
+                val expectedEffect =
+                    LetsPlayEffect.NavigateToGuessMovieByGenreScreen(mediumDifficulty.difficultyLevel.name)
+                assertThat(awaitItem()).isEqualTo(expectedEffect)
+            }
+        }
 
     @Test
     fun `onClickStartGame should do nothing if difficulty level is not selected`() = runTest {
-        viewModel.onClickGameCard(GameUiState.GameTypeUiState.GUESS_CHARACTER)
+        viewModel.onClickGameCard(Game.GameType.GUESS_CHARACTER)
         advanceUntilIdle()
 
         viewModel.effect.test {
@@ -188,8 +199,8 @@ class LetsPlayViewModelTest {
         games = listOf(
             Game(gameType = Game.GameType.GUESS_CHARACTER, requiredPoints = 0),
             Game(gameType = Game.GameType.GUESS_MOVIE_BY_POSTER, requiredPoints = 0),
-            Game(gameType = Game.GameType.GUESS_MOVIE_BY_RELEASE, requiredPoints = 400),
-            Game(gameType = Game.GameType.GUESS_MOVIE_BY_GENRE, requiredPoints = 400)
+            Game(gameType = Game.GameType.GUESS_RELEASE_YEAR, requiredPoints = 400),
+            Game(gameType = Game.GameType.GUESS_GENRE, requiredPoints = 400)
         ),
         difficultyLevels = listOf(
             GameDifficulty(5, 45, 5, GameDifficulty.DifficultyType.EASY),
@@ -198,15 +209,18 @@ class LetsPlayViewModelTest {
         )
     )
 
-    private val easyDifficulty = GameDifficultyUiState(5, 45, 5, GameDifficultyUiState.DifficultyLevelUiState.EASY)
-    private val mediumDifficulty = GameDifficultyUiState(10, 30, 10, GameDifficultyUiState.DifficultyLevelUiState.MEDIUM)
-    private val hardDifficulty = GameDifficultyUiState(20, 10, 20, GameDifficultyUiState.DifficultyLevelUiState.HARD)
+    private val easyDifficulty =
+        GameDifficultyUiState(5, 45, 5, GameDifficultyUiState.DifficultyLevelUiState.EASY)
+    private val mediumDifficulty =
+        GameDifficultyUiState(10, 30, 10, GameDifficultyUiState.DifficultyLevelUiState.MEDIUM)
+    private val hardDifficulty =
+        GameDifficultyUiState(20, 10, 20, GameDifficultyUiState.DifficultyLevelUiState.HARD)
 
     private val testDifficultiesUiState = listOf(easyDifficulty, mediumDifficulty, hardDifficulty)
     private val testGamesUiState = listOf(
-        GameUiState(GameUiState.GameTypeUiState.GUESS_CHARACTER, 0),
-        GameUiState(GameUiState.GameTypeUiState.GUESS_MOVIE_BY_POSTER, 0),
-        GameUiState(GameUiState.GameTypeUiState.GUESS_MOVIE_BY_RELEASE, 400),
-        GameUiState(GameUiState.GameTypeUiState.GUESS_MOVIE_BY_GENRE, 400)
+        GameUiState(Game.GameType.GUESS_CHARACTER, 0),
+        GameUiState(Game.GameType.GUESS_MOVIE_BY_POSTER, 0),
+        GameUiState(Game.GameType.GUESS_RELEASE_YEAR, 400),
+        GameUiState(Game.GameType.GUESS_GENRE, 400)
     )
 }


### PR DESCRIPTION
## Description
This PR fixes the crash when user clicks next in the last two screens. It also replaces the `GameTypeUiState` enum in the `viewModel` layer with the `Game.GameType` enum from the `entity` layer. 

This change streamlines the codebase by using a single source of truth for game types and avoid unnecessary mapping.

---
## Changes Made
Affected areas include:

- `GuessReleaseYearGameViewModel`
- `GameResultViewModel`
- `LetsPlayScreen` and related UI components
- `GuessMovieByPosterGameViewModel`
- `LetsPlayViewModel`
- `GuessGenreViewModel`
- `GuessCharacterGameViewModel`
- `ResultSideEffect`
- `LetsPlayInteractionListener`
- `LetsPlayUiStateMapper`
- `LetsPlayUiState`

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---
## Additional Comments

Relevant use cases and tests have been updated to reflect this change.
Renamed `GUESS_MOVIE_BY_RELEASE` to `GUESS_RELEASE_YEAR` in `Game.GameType` for consistency.
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.