### PR TITLE
Display title in game result app bar

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/gameResult/ResultScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/gameResult/ResultScreen.kt
@@ -33,16 +33,15 @@ import com.amsterdam.ui.screens.gameResult.component.CompletionCard
 import com.amsterdam.ui.screens.gameResult.component.GameResultAppBar
 import com.amsterdam.ui.screens.gameResult.component.StatCard
 import com.amsterdam.ui.screens.login.components.LoginBackground
+import com.amsterdam.viewmodel.gameResult.GameResultViewModel
 import com.amsterdam.viewmodel.gameResult.ResultInteractionListener
 import com.amsterdam.viewmodel.gameResult.ResultSideEffect
 import com.amsterdam.viewmodel.gameResult.ResultUiState
-import com.amsterdam.viewmodel.gameResult.GameResultViewModel
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun ResultScreen(
     viewModel: GameResultViewModel = hiltViewModel()
-
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val navigationManager = LocalNavManager.current
@@ -88,11 +87,13 @@ fun ResultScreenContent(
 ) {
     Scaffold(
         modifier = Modifier
-            .fillMaxSize()
-            .navigationBarsPadding(),
+                .fillMaxSize()
+                .navigationBarsPadding(),
         bottomBar = {
             Column(
-                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
@@ -122,19 +123,23 @@ fun ResultScreenContent(
 
             Column(
                 modifier = Modifier
-                    .fillMaxSize().padding(bottom = innerPadding.calculateBottomPadding())
-                    .verticalScroll(rememberScrollState())
-                    .statusBarsPadding()
-                    .navigationBarsPadding()
+                        .fillMaxSize()
+                        .padding(bottom = innerPadding.calculateBottomPadding())
+                        .verticalScroll(rememberScrollState())
+                        .statusBarsPadding()
+                        .navigationBarsPadding()
             ) {
-                GameResultAppBar(onCloseClicked = listener::onClickClose)
+                GameResultAppBar(
+                    gameType = state.gameType,
+                    onCloseClicked = listener::onClickClose
+                )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Column(
                     modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 12.dp),
+                            .fillMaxSize()
+                            .padding(horizontal = 12.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     CompletionCard()

--- a/ui/src/main/java/com/amsterdam/ui/screens/gameResult/component/GameResultAppBar.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/gameResult/component/GameResultAppBar.kt
@@ -15,23 +15,25 @@ import com.amsterdam.designsystem.components.TopAppBar
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
+import com.amsterdam.entity.Game
 import com.amsterdam.ui.R
 import com.amsterdam.designsystem.R as DesignSystemR
 
 
 @Composable
 fun GameResultAppBar(
+    gameType: Game.GameType,
     onCloseClicked: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     TopAppBar(
         modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
         containerColor = Color.Transparent,
         title = {
             Text(
-                text = stringResource(R.string.guess_character_game_title),
+                text = gameType.toStringResource(),
                 style = AppTheme.textStyle.title.large,
                 color = AppTheme.color.title,
                 fontSize = 20.sp
@@ -48,11 +50,23 @@ fun GameResultAppBar(
     )
 }
 
+@Composable
+private fun Game.GameType.toStringResource(): String {
+    return when (this) {
+        Game.GameType.GUESS_CHARACTER -> stringResource(R.string.guess_character_game_title)
+        Game.GameType.GUESS_MOVIE_BY_POSTER -> stringResource(R.string.guess_by_poster)
+        Game.GameType.GUESS_RELEASE_YEAR -> stringResource(R.string.release_game_title)
+        Game.GameType.GUESS_GENRE -> stringResource(R.string.genre_game_title)
+    }
+}
 
 @ThemeAndLocalePreviews
 @Composable
 private fun GameResultAppBarPreview() {
     AflamiTheme {
-        GameResultAppBar(onCloseClicked = {})
+        GameResultAppBar(
+            gameType = Game.GameType.GUESS_CHARACTER,
+            onCloseClicked = {}
+        )
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/GameResultViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/GameResultViewModel.kt
@@ -27,6 +27,7 @@ class GameResultViewModel @Inject constructor(
     init {
         updateState {
             it.copy(
+                gameType = gameType,
                 points = getCollectedPointsUseCase(gameSessionId),
                 timeInSeconds = getSpentSecondsUseCase(gameSessionId)
             )

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/ResultUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/gameResult/ResultUiState.kt
@@ -1,6 +1,9 @@
 package com.amsterdam.viewmodel.gameResult
 
+import com.amsterdam.entity.Game
+
 data class ResultUiState(
+    val gameType: Game.GameType = Game.GameType.GUESS_CHARACTER,
     val points: Int = 0,
     val timeInSeconds: Int = 0
 )


### PR DESCRIPTION
## Description
This PR introduces the functionality to display the specific game type (e.g., "Guess Character", "Guess by Poster") in the app bar of the game result screen.


---
## Changes Made

- Adding `gameType` to `ResultUiState`.
- Passing `gameType` from `GameResultViewModel` to `ResultUiState`.
- Passing `gameType` from `ResultScreenContent` to `GameResultAppBar`.
- Updating `GameResultAppBar` to display the game title based on the received `gameType`.
- Adding a composable extension function `Game.GameType.toStringResource()` to map game types to their string resources.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.