### PR TITLE
refactor: Introduce common game question components and add earned po…

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
@@ -1,7 +1,6 @@
 package com.amsterdam.ui.screens.games.character
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -34,10 +33,8 @@ import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.components.PageIndicator
-import com.amsterdam.ui.screens.games.component.AdaptiveAnswersColumn
-import com.amsterdam.ui.screens.games.component.GameScoreCircle
+import com.amsterdam.ui.screens.games.component.GameQuestionWithImage
 import com.amsterdam.ui.screens.games.component.GameTopBar
-import com.amsterdam.ui.screens.games.component.GuessPicture
 import com.amsterdam.ui.screens.games.component.NotEnoughPointsDialog
 import com.amsterdam.ui.screens.login.components.LoginBackground
 import com.amsterdam.viewmodel.guessCharacterGame.GuessCharacterGameEffect
@@ -87,8 +84,8 @@ private fun GameContent(
 
     Scaffold(
         modifier = Modifier
-                .fillMaxSize()
-                .navigationBarsPadding(),
+            .fillMaxSize()
+            .navigationBarsPadding(),
         bottomBar = {
             ConfirmButton(
                 title = stringResource(R.string.next),
@@ -97,8 +94,8 @@ private fun GameContent(
                 isLoading = false,
                 isNegative = false,
                 modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
+                    .fillMaxWidth()
+                    .padding(16.dp)
             )
         }
     ) { innerPadding ->
@@ -126,9 +123,9 @@ private fun GameContent(
             ) {
                 LazyColumn(
                     modifier = Modifier
-                            .fillMaxSize()
-                            .statusBarsPadding()
-                            .padding(bottom = innerPadding.calculateBottomPadding()),
+                        .fillMaxSize()
+                        .statusBarsPadding()
+                        .padding(bottom = innerPadding.calculateBottomPadding()),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     item {
@@ -142,10 +139,10 @@ private fun GameContent(
 
                             Row(
                                 Modifier
-                                        .wrapContentHeight()
-                                        .fillMaxWidth()
-                                        .padding(top = 16.dp)
-                                        .padding(horizontal = 16.dp),
+                                    .wrapContentHeight()
+                                    .fillMaxWidth()
+                                    .padding(top = 16.dp)
+                                    .padding(horizontal = 16.dp),
                                 horizontalArrangement = Arrangement.Center,
                             ) {
                                 PageIndicator(
@@ -163,13 +160,13 @@ private fun GameContent(
                             contentPadding = PaddingValues(horizontal = 12.dp),
                             pageSpacing = 12.dp,
                             modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 20.dp),
+                                .fillMaxWidth()
+                                .padding(top = 20.dp),
                         ) { page ->
                             val question = state.questions.getOrNull(page)
                             if (question != null) {
-                                CharacterGameQuestion(
-                                    questionImageModel = question.characterImageUrl,
+                                GameQuestionWithImage(
+                                    question = question.characterImageUrl,
                                     answers = question.characterChoices,
                                     blurRadius = question.blurRadius,
                                     selectedAnswerIndex = state.selectedAnswerIndex,
@@ -177,84 +174,14 @@ private fun GameContent(
                                     isHintEnabled = state.isHintEnabled,
                                     isChoicesEnabled = state.isNextEnabled,
                                     onHintClick = interactionListener::onHintClicked,
-                                    onSelectAnswer = interactionListener::onSelectAnswer
+                                    onSelectAnswer = interactionListener::onSelectAnswer,
+                                    earnedPoint = state.earnedPoints
                                 )
                             }
                         }
                     }
-
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun CharacterGameQuestion(
-    questionImageModel: String,
-    answers: List<String>,
-    blurRadius: Int,
-    selectedAnswerIndex: Int?,
-    isAnswerCorrect: Boolean?,
-    isHintEnabled: Boolean,
-    modifier: Modifier = Modifier,
-    isChoicesEnabled: Boolean = true,
-    onHintClick: () -> Unit = {},
-    onSelectAnswer: (Int) -> Unit = {},
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        CharacterImageWithScore(
-            questionImageModel = questionImageModel,
-            blurRadius = blurRadius,
-            isChoicesEnabled = isChoicesEnabled,
-            isAnswerCorrect = isAnswerCorrect,
-            isHintEnabled = isHintEnabled,
-            onHintClick = onHintClick,
-        )
-        AdaptiveAnswersColumn(
-            answers,
-            selectedAnswerIndex,
-            isAnswerCorrect,
-            isChoicesEnabled,
-            onSelectAnswer
-        )
-    }
-}
-
-@Composable
-fun CharacterImageWithScore(
-    questionImageModel: String,
-    blurRadius: Int,
-    isChoicesEnabled: Boolean,
-    isAnswerCorrect: Boolean?,
-    isHintEnabled: Boolean,
-    modifier: Modifier = Modifier,
-    onHintClick: () -> Unit = {}
-) {
-    Box(
-        modifier = modifier,
-        contentAlignment = Alignment.Center
-    ) {
-        GuessPicture(
-            blurRadius = blurRadius.dp,
-            points = 10,
-            imageUrl = questionImageModel,
-            isHintVisible = isHintEnabled,
-            onClick = onHintClick,
-        )
-        AnimatedVisibility(
-            visible = isChoicesEnabled && isAnswerCorrect ?: false,
-            enter = fadeIn(spring()),
-            exit = fadeOut(spring()),
-        ) {
-            GameScoreCircle(
-                score = 0,
-                modifier = Modifier.padding(bottom = if (isHintEnabled) 24.dp else 0.dp)
-            )
         }
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/component/GameQuestionWithImage.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/component/GameQuestionWithImage.kt
@@ -1,0 +1,46 @@
+package com.amsterdam.ui.screens.games.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun GameQuestionWithImage(
+    question: String,
+    blurRadius: Int,
+    answers: List<String>,
+    selectedAnswerIndex: Int?,
+    isAnswerCorrect: Boolean?,
+    isHintEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    isChoicesEnabled: Boolean = true,
+    onHintClick: () -> Unit = {},
+    onSelectAnswer: (Int) -> Unit = {},
+    earnedPoint: Int?,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+
+        QuestionImageWithScore(
+            questionImageModel = question,
+            blurRadius = blurRadius,
+            earnedPoint = earnedPoint,
+            isHintEnabled = isHintEnabled,
+            onHintClick = onHintClick,
+        )
+
+        AdaptiveAnswersColumn(
+            answers,
+            selectedAnswerIndex,
+            isAnswerCorrect,
+            isChoicesEnabled,
+            onSelectAnswer
+        )
+    }
+}

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/component/GameQuestionWithTitle.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/component/GameQuestionWithTitle.kt
@@ -1,0 +1,44 @@
+package com.amsterdam.ui.screens.games.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun GameQuestionWithTitle(
+    question: String,
+    answers: List<String>,
+    earnedPoint :Int?,
+    selectedAnswerIndex: Int?,
+    isAnswerCorrect: Boolean?,
+    isHintEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    isChoicesEnabled: Boolean = true,
+    onHintClick: () -> Unit = {},
+    onSelectAnswer: (Int) -> Unit = {},
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        GuessTitle(
+            title = question,
+            hintPoints = 10,
+            isHintVisible = isHintEnabled,
+            onClick = onHintClick,
+            earnedPoint = earnedPoint
+        )
+
+        AdaptiveAnswersColumn(
+            answers,
+            selectedAnswerIndex,
+            isAnswerCorrect,
+            isChoicesEnabled,
+            onSelectAnswer
+        )
+    }
+}

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/component/GameScoreCircle.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/component/GameScoreCircle.kt
@@ -3,7 +3,6 @@ package com.amsterdam.ui.screens.games.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -36,8 +35,7 @@ fun GameScoreCircle(
             text = "$sign$score",
             style = AppTheme.textStyle.label.large,
             color = textColor,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(vertical = 10.dp, horizontal = 11.dp)
+            textAlign = TextAlign.Center
         )
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/component/GuessTitle.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/component/GuessTitle.kt
@@ -1,5 +1,11 @@
 package com.amsterdam.ui.screens.games.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,26 +19,46 @@ import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 @Composable
 fun GuessTitle(
     title: String,
-    points: Int,
+    hintPoints: Int,
+    earnedPoint: Int?,
     isHintVisible: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     GuessCard(
-        points = points,
+        points = hintPoints,
         modifier = modifier,
         onClick = onClick,
         isHintVisible = isHintVisible,
     ) {
-        Text(
-            modifier =
-                Modifier
-                    .align(Alignment.Center)
-                    .padding(vertical = 65.dp),
-            text = title,
-            style = AppTheme.textStyle.title.large,
-            color = AppTheme.color.title,
-        )
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .padding(vertical = 65.dp),
+                text = title,
+                style = AppTheme.textStyle.title.large,
+                color = AppTheme.color.title,
+            )
+            AnimatedVisibility(
+                visible = earnedPoint != null && earnedPoint != 0,
+                enter = expandIn(
+                    expandFrom = Alignment.TopCenter,
+                    clip = false,
+                    animationSpec = tween(1000)
+                ) + fadeIn(animationSpec = tween(1000))
+            ) {
+                if (earnedPoint == null) return@AnimatedVisibility
+                GameScoreCircle(
+                    score = earnedPoint,
+                    modifier = Modifier.padding(bottom = if (isHintVisible) 24.dp else 0.dp)
+                )
+            }
+        }
     }
 }
 
@@ -42,9 +68,10 @@ private fun GuessTitleHintVisiblePreview() {
     AflamiTheme {
         GuessTitle(
             title = "The Green Mile",
-            points = 10,
+            hintPoints = 10,
             isHintVisible = true,
             onClick = {},
+            earnedPoint = 20,
         )
     }
 }
@@ -55,9 +82,10 @@ private fun GuessTitleHintNotVisiblePreview() {
     AflamiTheme {
         GuessTitle(
             title = "The Green Mile",
-            points = 10,
+            hintPoints = 10,
             isHintVisible = false,
             onClick = {},
+            earnedPoint = 20,
         )
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/component/QuestionImageWithScore.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/component/QuestionImageWithScore.kt
@@ -1,0 +1,49 @@
+package com.amsterdam.ui.screens.games.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandIn
+import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun QuestionImageWithScore(
+    questionImageModel: String,
+    blurRadius: Int,
+    earnedPoint: Int?,
+    isHintEnabled: Boolean,
+    modifier: Modifier = Modifier,
+    onHintClick: () -> Unit = {}
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        GuessPicture(
+            blurRadius = blurRadius.dp,
+            points = 10,
+            imageUrl = questionImageModel,
+            isHintVisible = isHintEnabled,
+            onClick = onHintClick,
+        )
+        AnimatedVisibility(
+            visible = earnedPoint != null && earnedPoint != 0,
+            enter = expandIn(
+                expandFrom = Alignment.TopCenter,
+                clip = false,
+                animationSpec = tween(1000)
+            ) + fadeIn(animationSpec = tween(1000))
+        ) {
+            if (earnedPoint == null) return@AnimatedVisibility
+            GameScoreCircle(
+                score = earnedPoint,
+                modifier = Modifier.padding(bottom = if (isHintEnabled) 24.dp else 0.dp)
+            )
+        }
+    }
+}

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,35 +23,26 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.amsterdam.ui.R
-import com.amsterdam.designsystem.components.buttons.IconButton
 import com.amsterdam.designsystem.components.LoadingContainer
 import com.amsterdam.designsystem.components.Scaffold
-import com.amsterdam.designsystem.components.Text
-import com.amsterdam.designsystem.components.TopAppBar
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.designsystem.theme.AflamiTheme
-import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.components.PageIndicator
-import com.amsterdam.ui.screens.games.component.AdaptiveAnswersColumn
-import com.amsterdam.ui.screens.games.component.GuessPicture
-import com.amsterdam.ui.screens.games.component.TimerComponent
+import com.amsterdam.ui.screens.games.component.GameQuestionWithImage
+import com.amsterdam.ui.screens.games.component.GameTopBar
 import com.amsterdam.ui.screens.games.component.NotEnoughPointsDialog
 import com.amsterdam.ui.screens.login.components.LoginBackground
 import com.amsterdam.viewmodel.guessMovieByPosterGame.GuessMovieByPosterGameEffect
 import com.amsterdam.viewmodel.guessMovieByPosterGame.GuessMovieByPosterGameViewModel
 import com.amsterdam.viewmodel.guessMovieByPosterGame.GuessMovieByPosterInteractionListener
 import com.amsterdam.viewmodel.guessMovieByPosterGame.GuessMovieByPosterUiState
-import com.amsterdam.viewmodel.sharedGame.TimerUiState
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -154,7 +144,8 @@ private fun GuessByPosterContent(
                 LazyColumn(
                     modifier =
                         modifier
-                            .fillMaxSize().statusBarsPadding()
+                            .fillMaxSize()
+                            .statusBarsPadding()
                             .padding(bottom = innerPadding.calculateBottomPadding())
                 ) {
                     item {
@@ -190,14 +181,18 @@ private fun GuessByPosterContent(
                                     .fillMaxWidth()
                                     .padding(top = 20.dp),
                         ) { page ->
-                            GameQuestion(
-                                question = state.questions[page],
+                            val question = state.questions[page]
+                            GameQuestionWithImage(
+                                question = question.posterUrl,
                                 isHintEnabled = state.isHintEnabled,
                                 selectedAnswerIndex = state.selectedAnswerIndex,
                                 isAnswerCorrect = state.isAnswerCorrect,
-                                isChoiceEnabled = state.isNextEnabled,
+                                isChoicesEnabled = state.isNextEnabled,
                                 onHintClick = interactionListener::onHintClicked,
                                 onSelectAnswer = interactionListener::onSelectAnswer,
+                                earnedPoint = state.earnedPoints,
+                                blurRadius = question.blurRadius,
+                                answers = question.movieNameChoices,
                             )
                         }
                     }
@@ -205,74 +200,6 @@ private fun GuessByPosterContent(
             }
         }
     }
-}
-
-@Composable
-fun GameQuestion(
-    question: GuessMovieByPosterUiState.QuestionUiState,
-    selectedAnswerIndex: Int?,
-    isAnswerCorrect: Boolean?,
-    isHintEnabled: Boolean,
-    modifier: Modifier = Modifier,
-    isChoiceEnabled: Boolean = true,
-    onHintClick: () -> Unit = {},
-    onSelectAnswer: (Int) -> Unit = {},
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        GuessPicture(
-            blurRadius = question.blurRadius.dp,
-            points = 10,
-            imageUrl = question.posterUrl,
-            isHintVisible = isHintEnabled,
-            onClick = {
-                onHintClick()
-            },
-        )
-        AdaptiveAnswersColumn(
-            question.movieNameChoices,
-            selectedAnswerIndex,
-            isAnswerCorrect,
-            isChoiceEnabled,
-            onSelectAnswer
-        )
-    }
-}
-
-@Composable
-internal fun GameTopBar(
-    title: String,
-    timerUiState: TimerUiState,
-    modifier: Modifier = Modifier,
-    onCancelGameClick: () -> Unit = {},
-) {
-    TopAppBar(
-        modifier = modifier,
-        containerColor = Color.Transparent,
-        title = {
-            Text(
-                text = title,
-                color = AppTheme.color.title,
-                style = AppTheme.textStyle.title.large,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        },
-        leadingIcon = {
-            IconButton(
-                painter = painterResource(com.amsterdam.designsystem.R.drawable.ic_cancel),
-                tint = AppTheme.color.title,
-                contentDescription = stringResource(R.string.back_to_menue),
-                onClick = onCancelGameClick,
-            )
-        },
-        trailingIcon = {
-            TimerComponent(timerUiState)
-        },
-    )
 }
 
 @ThemeAndLocalePreviews

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,12 +33,10 @@ import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.screens.games.component.GameTopBar
 import com.amsterdam.ui.components.PageIndicator
-import com.amsterdam.ui.screens.games.component.AdaptiveAnswersColumn
-import com.amsterdam.ui.screens.games.component.GuessTitle
+import com.amsterdam.ui.screens.games.component.GameQuestionWithTitle
 import com.amsterdam.ui.screens.games.component.NotEnoughPointsDialog
 import com.amsterdam.ui.screens.login.components.LoginBackground
 import com.amsterdam.ui.screens.search.keywordSearch.sections.filterDialog.genre.uiModel
-import com.amsterdam.viewmodel.guessWhichGenre.GameQuestionUiState
 import com.amsterdam.viewmodel.guessWhichGenre.GenreGameEffect
 import com.amsterdam.viewmodel.guessWhichGenre.GenreGameInteractionListener
 import com.amsterdam.viewmodel.guessWhichGenre.GenreGameUiState
@@ -170,52 +167,22 @@ private fun GameScreenContent(
                                     .fillMaxWidth()
                                     .padding(top = 20.dp),
                         ) { page ->
-                            GameQuestion(
-                                question = state.questions[page],
+                            val question = state.questions[page]
+                            GameQuestionWithTitle(
+                                question = question.questionData,
                                 isHintEnabled = state.isHintEnabled,
                                 selectedAnswerIndex = state.selectedAnswerIndex,
                                 isAnswerCorrect = state.isAnswerCorrect,
-                                isChoiceEnabled = state.isNextEnabled,
+                                isChoicesEnabled = state.isNextEnabled,
                                 onHintClick = interactionListener::onUseHint,
                                 onSelectAnswer = interactionListener::onChooseAnswerClick,
+                                answers = question.answers.map { stringResource(it.uiModel.displayableName) },
+                                earnedPoint = state.earnedPoints
                             )
                         }
                     }
                 }
             }
         }
-    }
-}
-
-@Composable
-fun GameQuestion(
-    question: GameQuestionUiState,
-    selectedAnswerIndex: Int?,
-    isAnswerCorrect: Boolean?,
-    isHintEnabled: Boolean,
-    modifier: Modifier = Modifier,
-    isChoiceEnabled: Boolean = true,
-    onHintClick: () -> Unit = {},
-    onSelectAnswer: (answerIndex: Int) -> Unit = { },
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        GuessTitle(
-            title = question.questionData,
-            points = 10,
-            isHintVisible = isHintEnabled,
-            onClick = onHintClick,
-        )
-        AdaptiveAnswersColumn(
-            question.answers.map { stringResource(it.uiModel.displayableName) },
-            selectedAnswerIndex,
-            isAnswerCorrect,
-            isChoiceEnabled,
-            onSelectAnswer
-        )
-
     }
 }

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,8 +33,7 @@ import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavManager
 import com.amsterdam.ui.screens.games.component.GameTopBar
 import com.amsterdam.ui.components.PageIndicator
-import com.amsterdam.ui.screens.games.component.AdaptiveAnswersColumn
-import com.amsterdam.ui.screens.games.component.GuessTitle
+import com.amsterdam.ui.screens.games.component.GameQuestionWithTitle
 import com.amsterdam.ui.screens.games.component.NotEnoughPointsDialog
 import com.amsterdam.ui.screens.login.components.LoginBackground
 import com.amsterdam.viewmodel.guessReleseDateGame.GuessReleaseYearGameEffect
@@ -161,7 +159,7 @@ private fun GameContent(
                                     .padding(top = 20.dp),
                         ) { page ->
                             val question = state.questions[page]
-                            ReleaseYearGameQuestion(
+                            GameQuestionWithTitle(
                                 question = question.movieName,
                                 answers = question.releaseYearAnswer,
                                 selectedAnswerIndex = state.selectedAnswerIndex,
@@ -170,46 +168,12 @@ private fun GameContent(
                                 isChoicesEnabled = state.isNextEnabled,
                                 onHintClick = interactionListener::onHintClicked,
                                 onSelectAnswer = interactionListener::onSelectAnswer,
+                                earnedPoint = state.earnedPoints
                             )
                         }
                     }
-
                 }
             }
         }
-    }
-}
-
-@Composable
-fun ReleaseYearGameQuestion(
-    question: String,
-    answers: List<String>,
-    selectedAnswerIndex: Int?,
-    isAnswerCorrect: Boolean?,
-    isHintEnabled: Boolean,
-    modifier: Modifier = Modifier,
-    isChoicesEnabled: Boolean = true,
-    onHintClick: () -> Unit = {},
-    onSelectAnswer: (Int) -> Unit = {},
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        GuessTitle(
-            title = question,
-            points = 10,
-            isHintVisible = isHintEnabled,
-            onClick = onHintClick,
-        )
-
-        AdaptiveAnswersColumn(
-            answers,
-            selectedAnswerIndex,
-            isAnswerCorrect,
-            isChoicesEnabled,
-            onSelectAnswer
-        )
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
@@ -138,7 +138,8 @@ class GuessCharacterGameViewModel @Inject constructor(
             it.copy(
                 isAnswerCorrect = answerResult.isCorrect,
                 isNextEnabled = true,
-                selectedAnswerIndex = selectedAnswerIndex
+                selectedAnswerIndex = selectedAnswerIndex,
+                earnedPoints = answerResult.earnedPoints
             )
         }
         addPointsToGameUseCase(answerResult.earnedPoints, state.value.gameSessionId)
@@ -176,7 +177,8 @@ class GuessCharacterGameViewModel @Inject constructor(
                 selectedAnswerIndex = null,
                 isAnswerCorrect = null,
                 isNextEnabled = false,
-                isNotEnoughPointsDialogVisible = false
+                isNotEnoughPointsDialogVisible = false,
+                earnedPoints = null
             )
         }
         startTheTimer()

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterUiState.kt
@@ -13,6 +13,7 @@ data class GuessCharacterUiState(
     val isHintEnabled : Boolean = true,
     val isNotEnoughPointsDialogVisible: Boolean = false,
     val isNextEnabled : Boolean = false,
+    val earnedPoints : Int? = null,
     val questionsCounts: Int = 0,
     val currentQuestionIndex: Int = 0,
     val timerUiState : TimerUiState = TimerUiState()

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
@@ -141,7 +141,8 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
             it.copy(
                 isAnswerCorrect = answerResult.isCorrect,
                 isNextEnabled = true,
-                selectedAnswerIndex = selectedAnswerIndex
+                selectedAnswerIndex = selectedAnswerIndex,
+                earnedPoints = answerResult.earnedPoints
             )
         }
         addPointsToGameUseCase(answerResult.earnedPoints, state.value.gameSessionId)
@@ -166,26 +167,36 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
         val nextQuestionIndex = currentQuestionIndex + 1
 
         if (nextQuestionIndex < state.value.questions.size) {
-            updateState {
-                it.copy(
-                    currentQuestionIndex = nextQuestionIndex,
-                    selectedAnswerIndex = null,
-                    isAnswerCorrect = null,
-                    isNextEnabled = false,
-                    isNotEnoughPointsDialogVisible = false
-                )
-            }
-            startTheTimer()
+            handleMoveToNextQuestion(nextQuestionIndex)
         } else {
-            val resultData = ResultScreenData(
-                difficulty = difficultyType.name,
-                gameType = Game.GameType.GUESS_MOVIE_BY_POSTER.name,
-                gameSessionId = state.value.gameSessionId
-            )
-            sendNewNavigationEffect(
-                GuessMovieByPosterGameEffect.NavigateToGameResult(resultData)
+            handleGameFinished()
+        }
+    }
+
+
+    private fun handleMoveToNextQuestion(nextQuestionIndex: Int) {
+        updateState {
+            it.copy(
+                currentQuestionIndex = nextQuestionIndex,
+                selectedAnswerIndex = null,
+                isAnswerCorrect = null,
+                isNextEnabled = false,
+                isNotEnoughPointsDialogVisible = false,
+                earnedPoints = null
             )
         }
+        startTheTimer()
+    }
+
+    private fun handleGameFinished() {
+        val resultData = ResultScreenData(
+            difficulty = difficultyType.name,
+            gameType = Game.GameType.GUESS_MOVIE_BY_POSTER.name,
+            gameSessionId = state.value.gameSessionId
+        )
+        sendNewNavigationEffect(
+            GuessMovieByPosterGameEffect.NavigateToGameResult(resultData)
+        )
     }
 
     override fun dismissNotEnoughPointsDialog() {

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterUiState.kt
@@ -7,6 +7,7 @@ data class GuessMovieByPosterUiState(
     val isLoading: Boolean = true,
     val totalCollectedPoints: Int = 0,
     val gameSessionId : Long = 0,
+    val earnedPoints : Int? = null,
     val questions: List<QuestionUiState> = emptyList(),
     val selectedAnswerIndex: Int? = null,
     val isAnswerCorrect: Boolean? = null,

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearGameViewModel.kt
@@ -138,7 +138,8 @@ class GuessReleaseYearGameViewModel @Inject constructor(
             it.copy(
                 isAnswerCorrect = answerResult.isCorrect,
                 isNextEnabled = true,
-                selectedAnswerIndex = selectedAnswerIndex
+                selectedAnswerIndex = selectedAnswerIndex,
+                earnedPoints = answerResult.earnedPoints
             )
         }
         addPointsToGameUseCase(answerResult.earnedPoints, state.value.gameSessionId)
@@ -149,26 +150,35 @@ class GuessReleaseYearGameViewModel @Inject constructor(
         val currentQuestionIndex = state.value.currentQuestionIndex
         val nextQuestionIndex = currentQuestionIndex + 1
         if (nextQuestionIndex < state.value.questions.size) {
-            updateState {
-                it.copy(
-                    currentQuestionIndex = nextQuestionIndex,
-                    selectedAnswerIndex = null,
-                    isAnswerCorrect = null,
-                    isNextEnabled = false,
-                    isNotEnoughPointsDialogVisible = false
-                )
-            }
-            startTheTimer()
+            handleMoveToNextQuestion(nextQuestionIndex)
         } else {
-            val resultData = ResultScreenData(
-                difficulty = difficultyType.name,
-                gameType = Game.GameType.GUESS_RELEASE_YEAR.name,
-                gameSessionId = state.value.gameSessionId
-            )
-            sendNewNavigationEffect(
-                GuessReleaseYearGameEffect.NavigateToGameResult(resultData)
+            handleGameFinished()
+        }
+    }
+
+    private fun handleMoveToNextQuestion(nextQuestionIndex: Int) {
+        updateState {
+            it.copy(
+                currentQuestionIndex = nextQuestionIndex,
+                selectedAnswerIndex = null,
+                isAnswerCorrect = null,
+                isNextEnabled = false,
+                isNotEnoughPointsDialogVisible = false,
+                earnedPoints = null
             )
         }
+        startTheTimer()
+    }
+
+    private fun handleGameFinished() {
+        val resultData = ResultScreenData(
+            difficulty = difficultyType.name,
+            gameType = Game.GameType.GUESS_RELEASE_YEAR.name,
+            gameSessionId = state.value.gameSessionId
+        )
+        sendNewNavigationEffect(
+            GuessReleaseYearGameEffect.NavigateToGameResult(resultData)
+        )
     }
 
     private fun increaseSpentTimeSecondsByOne() {

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearUiState.kt
@@ -6,6 +6,7 @@ data class GuessReleaseYearUiState(
     val isLoading: Boolean = true,
     val timerCounter: Int = 0,
     val gameSessionId : Long = 0,
+    val earnedPoints : Int? = null,
     val totalCollectedPoints: Int = 0,
     val questions: List<QuestionUiState> = emptyList(),
     val selectedAnswerIndex: Int? = null,

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameUiState.kt
@@ -8,6 +8,7 @@ data class GenreGameUiState(
     val isLoading: Boolean = false,
     val questions: List<GameQuestionUiState> = emptyList(),
     val currentQuestionIndex: Int = 0,
+    val earnedPoints : Int? = null,
     val gameSessionId : Long = 0,
     val isHintEnabled: Boolean = true,
     val isNotEnoughPointsDialogVisible: Boolean = false,

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GuessGenreViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GuessGenreViewModel.kt
@@ -13,7 +13,6 @@ import com.amsterdam.entity.Game
 import com.amsterdam.entity.GameDifficulty.DifficultyType
 import com.amsterdam.entity.category.MovieGenre
 import com.amsterdam.viewmodel.gameResult.ResultScreenData
-import com.amsterdam.viewmodel.gameResult.ResultSideEffect
 import com.amsterdam.viewmodel.shared.BaseViewModel
 import com.amsterdam.viewmodel.sharedGame.TimerUiState
 import com.amsterdam.viewmodel.utils.dispatcher.DispatcherProvider
@@ -124,7 +123,8 @@ class GuessGenreViewModel @Inject constructor(
                 selectedAnswerIndex = answerIndex,
                 isAnswerCorrect = answerResult.isCorrect,
                 isNextEnabled = true,
-                isNotEnoughPointsDialogVisible = false
+                isNotEnoughPointsDialogVisible = false,
+                earnedPoints = answerResult.earnedPoints
             )
         }
         addPointsToGameUseCase(answerResult.earnedPoints, state.value.gameSessionId)
@@ -160,23 +160,32 @@ class GuessGenreViewModel @Inject constructor(
     override fun onMoveToNextQuestion() {
         val nextQuestionIndex = state.value.currentQuestionIndex + 1
         if (nextQuestionIndex < state.value.questions.size) {
-            updateState {
-                it.copy(
-                    currentQuestionIndex = nextQuestionIndex,
-                    selectedAnswerIndex = null,
-                    isAnswerCorrect = null,
-                    isNextEnabled = false
-                )
-            }
-            startTheTimer()
+            handleMoveToNextQuestion(nextQuestionIndex)
         } else {
-            val resultData = ResultScreenData(
-                difficulty = difficultyType.name,
-                gameType = Game.GameType.GUESS_GENRE.name,
-                gameSessionId = state.value.gameSessionId
-            )
-            sendNewNavigationEffect(GenreGameEffect.GameOver(resultData))
+            handleGameFinished()
         }
+    }
+
+    private fun handleMoveToNextQuestion(nextQuestionIndex: Int) {
+        updateState {
+            it.copy(
+                currentQuestionIndex = nextQuestionIndex,
+                selectedAnswerIndex = null,
+                isAnswerCorrect = null,
+                isNextEnabled = false,
+                earnedPoints = null
+            )
+        }
+        startTheTimer()
+    }
+
+    private fun handleGameFinished() {
+        val resultData = ResultScreenData(
+            difficulty = difficultyType.name,
+            gameType = Game.GameType.GUESS_GENRE.name,
+            gameSessionId = state.value.gameSessionId
+        )
+        sendNewNavigationEffect(GenreGameEffect.GameOver(resultData))
     }
 
     override fun dismissNotEnoughPointsDialog() {


### PR DESCRIPTION
# Pull Request Template

## Description
This commit refactors the game screens to use new common components for displaying questions: `GameQuestionWithTitle` and `GameQuestionWithImage`. This helps to reduce code duplication and improve maintainability.

Additionally, earned points are now displayed on the question card after an answer is submitted, providing immediate feedback to the user.
---

## Changes Made
List the changes introduced in this pull request:
**UI Layer:**

*   Added `GameQuestionWithTitle.kt`: A composable for displaying game questions that consist of a title and answer choices.
*   Added `GameQuestionWithImage.kt`: A composable for displaying game questions that consist of an image and answer choices.
*   Added `QuestionImageWithScore.kt`: A composable that wraps the `GuessPicture` component and adds an animated display for earned points.
*   Modified `GuessReleaseYearGameScreen.kt`:
    *   Replaced the local `ReleaseYearGameQuestion` composable with the new `GameQuestionWithTitle`.
    *   Removed unused imports.
*   Modified `GuessByPosterScreen.kt`:
    *   Replaced the local `GameQuestion` composable with the new `GameQuestionWithImage`.
    *   Removed the local `GameTopBar` composable (now part of the shared game components).
    *   Removed unused imports.
*   Modified `GuessCharacterScreen.kt`:
    *   Replaced the local `CharacterGameQuestion` composable with the new `GameQuestionWithImage`.
    *   Removed the local `CharacterImageWithScore` composable as its functionality is now part of `QuestionImageWithScore`.
*   Modified `GuessGenreScreen.kt`:
    *   Replaced the local `GameQuestion` composable with the new `GameQuestionWithTitle`.
*   Modified `GuessTitle.kt`:
    *   Added an `earnedPoint` parameter.
    *   Wrapped the title text and the new `GameScoreCircle` (for earned points) in a `Box` to allow overlaying.
    *   Added `AnimatedVisibility` for the `GameScoreCircle` to show earned points with an animation.
    *   Renamed `points` parameter to `hintPoints` for clarity.
*   Modified `GameScoreCircle.kt`: Adjusted padding and text alignment.

**ViewModel Layer:**

*   Added `earnedPoints: Int?` to the following UI state classes to track points earned for the current question:
    *   `GuessReleaseYearUiState.kt`
    *   `GuessMovieByPosterUiState.kt`
    *   `GenreGameUiState.kt`
    *   `GuessCharacterUiState.kt`
*   Updated the following ViewModels to set `earnedPoints` in the UI state when an answer is submitted and reset it to `null` when moving to the next question or finishing the game:
    *   `GuessReleaseYearGameViewModel.kt`
    *   `GuessMovieByPosterGameViewModel.kt`
    *   `GuessGenreViewModel.kt`
    *   `GuessCharacterGameViewModel.kt`
---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.
<table>
 <tbody>
    <tr>
<td>Before</td>
      <td>

https://github.com/user-attachments/assets/22c735ff-0268-4686-9ac6-4d507825f0c0

</td>
    </tr>
    <tr>
<td>After</td>
    <td>

https://github.com/user-attachments/assets/08018685-05d6-42d5-afeb-7132dca95230

    </td>
  </tr>
 </tbody>

</table>


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.