### PR TITLE
Refactor/handle network error in games

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
@@ -32,6 +32,7 @@ import com.amsterdam.designsystem.components.Scaffold
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavManager
+import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.components.PageIndicator
 import com.amsterdam.ui.screens.games.component.GameQuestionWithImage
 import com.amsterdam.ui.screens.games.component.GameTopBar
@@ -99,6 +100,23 @@ private fun GameContent(
             )
         }
     ) { innerPadding ->
+
+        AnimatedVisibility(
+            state.isNetworkError,
+            enter = fadeIn(tween(1000)),
+            exit = fadeOut(tween(1000)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                NoNetworkContainer(
+                    onClickRetry = interactionListener::onClickRetryLoading,
+                )
+            }
+        }
+
         Box {
             LoginBackground()
             AnimatedVisibility(state.isNotEnoughPointsDialogVisible) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
@@ -34,6 +34,7 @@ import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.designsystem.theme.AflamiTheme
 import com.amsterdam.designsystem.utils.ThemeAndLocalePreviews
 import com.amsterdam.ui.application.LocalNavManager
+import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.components.PageIndicator
 import com.amsterdam.ui.screens.games.component.GameQuestionWithImage
 import com.amsterdam.ui.screens.games.component.GameTopBar
@@ -119,6 +120,22 @@ private fun GuessByPosterContent(
         }
     ) { innerPadding ->
 
+        AnimatedVisibility(
+            state.isNetworkError,
+            enter = fadeIn(tween(1000)),
+            exit = fadeOut(tween(1000)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                NoNetworkContainer(
+                    onClickRetry = interactionListener::onClickRetryLoading,
+                )
+            }
+        }
+
         Box {
             LoginBackground()
             AnimatedVisibility(state.isNotEnoughPointsDialogVisible) {
@@ -132,7 +149,10 @@ private fun GuessByPosterContent(
                 enter = fadeIn(tween(600)),
                 exit = fadeOut(tween(100)),
             ) {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
                     LoadingContainer()
                 }
             }
@@ -152,7 +172,10 @@ private fun GuessByPosterContent(
                         GameTopBar(
                             title = topBarTitle,
                             timerUiState = state.timerUiState,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            modifier = Modifier.padding(
+                                horizontal = 16.dp,
+                                vertical = 8.dp
+                            ),
                             onCancelGameClick = interactionListener::onCloseButtonClicked
                         )
 
@@ -227,6 +250,7 @@ private fun GuessByPosterScreenPreview() {
             interactionListener =
                 object : GuessMovieByPosterInteractionListener {
                     override fun onCloseButtonClicked() {}
+                    override fun onClickRetryLoading() {}
                     override fun onHintClicked() {}
                     override fun onSelectAnswer(selectedAnswerIndex: Int) {}
                     override fun onMoveToNextQuestion() {}

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
@@ -31,6 +31,7 @@ import com.amsterdam.designsystem.components.LoadingContainer
 import com.amsterdam.designsystem.components.Scaffold
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.ui.application.LocalNavManager
+import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.screens.games.component.GameTopBar
 import com.amsterdam.ui.components.PageIndicator
 import com.amsterdam.ui.screens.games.component.GameQuestionWithTitle
@@ -83,6 +84,7 @@ private fun GameScreenContent(
     LaunchedEffect(state.currentQuestionIndex) {
         scope.launch { pagerState.animateScrollToPage(state.currentQuestionIndex) }
     }
+
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -107,6 +109,23 @@ private fun GameScreenContent(
             }
         }
     ) { innerPadding ->
+
+        AnimatedVisibility(
+            state.isNetworkError,
+            enter = fadeIn(tween(1000)),
+            exit = fadeOut(tween(1000)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                NoNetworkContainer(
+                    onClickRetry = interactionListener::onClickRetryLoading,
+                )
+            }
+        }
+
         Box {
             LoginBackground()
             AnimatedVisibility(state.isNotEnoughPointsDialogVisible) {

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
@@ -31,6 +31,7 @@ import com.amsterdam.designsystem.components.Scaffold
 import com.amsterdam.designsystem.components.buttons.ConfirmButton
 import com.amsterdam.ui.R
 import com.amsterdam.ui.application.LocalNavManager
+import com.amsterdam.ui.components.NoNetworkContainer
 import com.amsterdam.ui.screens.games.component.GameTopBar
 import com.amsterdam.ui.components.PageIndicator
 import com.amsterdam.ui.screens.games.component.GameQuestionWithTitle
@@ -81,6 +82,8 @@ private fun GameContent(
     LaunchedEffect(state.currentQuestionIndex) {
         scope.launch { pagerState.animateScrollToPage(state.currentQuestionIndex) }
     }
+
+
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -98,6 +101,23 @@ private fun GameContent(
             )
         }
     ) { innerPadding ->
+
+        AnimatedVisibility(
+            state.isNetworkError,
+            enter = fadeIn(tween(1000)),
+            exit = fadeOut(tween(1000)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                NoNetworkContainer(
+                    onClickRetry = interactionListener::onClickRetryLoading,
+                )
+            }
+        }
+
         Box {
             LoginBackground()
             AnimatedVisibility(state.isNotEnoughPointsDialogVisible) {

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterGameViewModel.kt
@@ -40,7 +40,7 @@ class GuessCharacterGameViewModel @Inject constructor(
     }
 
     private fun getQuestions() {
-        updateState { it.copy(isLoading = true) }
+        updateState { it.copy(isLoading = true, isNetworkError = false) }
         tryToExecute(
             action = ::startTheGame,
             onSuccess = ::onSuccessGetQuestions,
@@ -203,6 +203,10 @@ class GuessCharacterGameViewModel @Inject constructor(
         sendNewNavigationEffect(GuessCharacterGameEffect.NavigateBack)
     }
 
+    override fun onClickRetryLoading() {
+        getQuestions()
+    }
+
     private fun increaseSpentTimeSecondsByOne() {
         addSecondToGameTimeUseCase(state.value.gameSessionId)
     }
@@ -210,7 +214,7 @@ class GuessCharacterGameViewModel @Inject constructor(
     private fun onError(error: AflamiException) {
         when (error) {
             is NotEnoughPointsException -> updateState { it.copy(isNotEnoughPointsDialogVisible = true) }
-
+            else ->  updateState { it.copy(isNetworkError = true) }
         }
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterInteractionListener.kt
@@ -6,4 +6,5 @@ interface GuessCharacterInteractionListener {
     fun onMoveToNextQuestion()
     fun dismissNotEnoughPointsDialog()
     fun onCloseButtonClicked()
+    fun onClickRetryLoading()
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessCharacterGame/GuessCharacterUiState.kt
@@ -13,6 +13,7 @@ data class GuessCharacterUiState(
     val isHintEnabled : Boolean = true,
     val isNotEnoughPointsDialogVisible: Boolean = false,
     val isNextEnabled : Boolean = false,
+    val isNetworkError : Boolean = false,
     val earnedPoints : Int? = null,
     val questionsCounts: Int = 0,
     val currentQuestionIndex: Int = 0,

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterGameViewModel.kt
@@ -41,7 +41,7 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
     }
 
     private fun getQuestions() {
-        updateState { it.copy(isLoading = true) }
+        updateState { it.copy(isLoading = true, isNetworkError = false) }
         tryToExecute(
             action = ::startTheGame,
             onSuccess = ::onSuccessGetQuestions,
@@ -212,9 +212,14 @@ class GuessMovieByPosterGameViewModel @Inject constructor(
         sendNewNavigationEffect(GuessMovieByPosterGameEffect.NavigateBack)
     }
 
+    override fun onClickRetryLoading() {
+        getQuestions()
+    }
+
     private fun onError(error: AflamiException) {
         when (error) {
             is NotEnoughPointsException -> updateState { it.copy(isNotEnoughPointsDialogVisible = true) }
+            else -> updateState { it.copy(isNetworkError = true) }
         }
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterInteractionListener.kt
@@ -6,4 +6,5 @@ interface GuessMovieByPosterInteractionListener {
     fun onMoveToNextQuestion()
     fun dismissNotEnoughPointsDialog()
     fun onCloseButtonClicked()
+    fun onClickRetryLoading()
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessMovieByPosterGame/GuessMovieByPosterUiState.kt
@@ -15,7 +15,8 @@ data class GuessMovieByPosterUiState(
     val isNotEnoughPointsDialogVisible: Boolean = false,
     val isNextEnabled: Boolean = false,
     val currentQuestionIndex: Int = 0,
-    val timerUiState: TimerUiState = TimerUiState()
+    val timerUiState: TimerUiState = TimerUiState(),
+    val isNetworkError : Boolean = false
 ) {
     data class QuestionUiState(
         val posterUrl: String = "",

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearGameViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearGameViewModel.kt
@@ -36,11 +36,11 @@ class GuessReleaseYearGameViewModel @Inject constructor(
     private val difficultyType = DifficultyType.valueOf(args.difficulty)
 
     init {
-        fetchQuestions()
+        getQuestions()
     }
 
-    private fun fetchQuestions() {
-        updateState { it.copy(isLoading = true) }
+    private fun getQuestions() {
+        updateState { it.copy(isLoading = true, isNetworkError = false) }
         tryToExecute(
             action = ::startTheGame,
             onSuccess = ::onSuccessGetQuestions,
@@ -197,9 +197,14 @@ class GuessReleaseYearGameViewModel @Inject constructor(
         sendNewNavigationEffect(GuessReleaseYearGameEffect.NavigateBack)
     }
 
+    override fun onClickRetryLoading() {
+        getQuestions()
+    }
+
     private fun onError(error: AflamiException) {
         when (error) {
             is NotEnoughPointsException -> updateState { it.copy(isNotEnoughPointsDialogVisible = true) }
+            else -> updateState { it.copy(isNetworkError = true) }
         }
     }
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearInteractionListener.kt
@@ -7,4 +7,5 @@ interface GuessReleaseYearInteractionListener {
     fun onCloseButtonClicked()
     fun dismissNotEnoughPointsDialog()
     fun onClickClose()
+    fun onClickRetryLoading()
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessReleseDateGame/GuessReleaseYearUiState.kt
@@ -16,7 +16,8 @@ data class GuessReleaseYearUiState(
     val isNextEnabled: Boolean = false,
     val questionsCounts: Int = 0,
     val currentQuestionIndex: Int = 0,
-    val timerUiState: TimerUiState = TimerUiState()
+    val timerUiState: TimerUiState = TimerUiState(),
+    val isNetworkError : Boolean = false
 ) {
     data class QuestionUiState(
         val movieName: String = "",

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameInteractionListener.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameInteractionListener.kt
@@ -6,4 +6,5 @@ interface GenreGameInteractionListener {
     fun onChooseAnswerClick(answerIndex: Int)
     fun dismissNotEnoughPointsDialog()
     fun onMoveToNextQuestion()
+    fun onClickRetryLoading()
 }

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameUiState.kt
@@ -16,7 +16,7 @@ data class GenreGameUiState(
     val isNextEnabled: Boolean = false,
     val selectedAnswerIndex: Int? = null,
     val isAnswerCorrect: Boolean? = null,
-    val error: AflamiException? = null
+    val isNetworkError : Boolean = false
 )
 
 data class GameQuestionUiState(

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameUiState.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GenreGameUiState.kt
@@ -1,6 +1,5 @@
 package com.amsterdam.viewmodel.guessWhichGenre
 
-import com.amsterdam.domain.exceptions.AflamiException
 import com.amsterdam.entity.category.MovieGenre
 import com.amsterdam.viewmodel.sharedGame.TimerUiState
 

--- a/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GuessGenreViewModel.kt
+++ b/viewModel/src/main/java/com/amsterdam/viewmodel/guessWhichGenre/GuessGenreViewModel.kt
@@ -38,11 +38,11 @@ class GuessGenreViewModel @Inject constructor(
     private val difficultyType = DifficultyType.valueOf(args.difficulty)
 
     init {
-        fetchQuestions()
+        getQuestions()
     }
 
-    private fun fetchQuestions() {
-        updateState { it.copy(isLoading = true) }
+    private fun getQuestions() {
+        updateState { it.copy(isLoading = true, isNetworkError = false) }
         tryToExecute(
             action = ::startTheGame,
             onSuccess = ::onSuccessGetQuestions,
@@ -166,6 +166,10 @@ class GuessGenreViewModel @Inject constructor(
         }
     }
 
+    override fun onClickRetryLoading() {
+        getQuestions()
+    }
+
     private fun handleMoveToNextQuestion(nextQuestionIndex: Int) {
         updateState {
             it.copy(
@@ -199,6 +203,7 @@ class GuessGenreViewModel @Inject constructor(
     private fun onError(error: AflamiException) {
         when (error) {
             is NotEnoughPointsException -> updateState { it.copy(isNotEnoughPointsDialogVisible = true) }
+            else -> updateState { it.copy(isNetworkError = true) }
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description
introduces network error handling for all game screens.
---

## Changes Made
List the changes introduced in this pull request:

**UI Layer:**
- Added `NoNetworkContainer` to `GuessReleaseYearGameScreen.kt`, `GuessByPosterScreen.kt`, `GuessCharacterScreen.kt`, and `GuessGenreScreen.kt`.
- This container is displayed when `isNetworkError` is true in the UI state.
- It provides a "Retry" button that triggers `onClickRetryLoading` in the respective interaction listeners.

**ViewModel Layer:**
- **GuessReleaseYearGameViewModel:**
    - Modified `getQuestions()` to set `isNetworkError = false` initially.
    - Added `onClickRetryLoading()` to call `getQuestions()`.
    - `onError()` now updates `isNetworkError = true` for general errors.
- **GuessMovieByPosterGameViewModel:**
    - Modified `getQuestions()` to set `isNetworkError = false` initially.
    - Added `onClickRetryLoading()` to call `getQuestions()`.
    - `onError()` now updates `isNetworkError = true` for general errors.
- **GuessGenreViewModel:**
    - Modified `getQuestions()` (renamed from `fetchQuestions`) to set `isNetworkError = false` initially.
    - Added `onClickRetryLoading()` to call `getQuestions()`.
    - `onError()` now updates `isNetworkError = true` for general errors.
- **GuessCharacterGameViewModel:**
    - Modified `getQuestions()` to set `isNetworkError = false` initially.
    - Added `onClickRetryLoading()` to call `getQuestions()`.
    - `onError()` now updates `isNetworkError = true` for general errors.

**UI State & Interaction Listeners:**
- Added `isNetworkError: Boolean` to `GuessReleaseYearUiState`, `GenreGameUiState`, `GuessCharacterUiState`, and `GuessMovieByPosterUiState`.
- Added `onClickRetryLoading()` to `GuessReleaseYearInteractionListener`, `GenreGameInteractionListener`, `GuessCharacterInteractionListener`, and `GuessMovieByPosterInteractionListener`.

---

## Screenshots (if applicable)
<table>
  <thead>
    <tr>
      <th>Right Now Behaviour</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>


https://github.com/user-attachments/assets/4f5f6939-a93a-45d5-8784-c9bb97706c9b



  </tbody>
</table>
---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.