### PR TITLE
refactor: remove redundant Box in game screens

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/games/component/GuessTitle.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/component/GuessTitle.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AflamiTheme
@@ -43,6 +44,7 @@ fun GuessTitle(
                 text = title,
                 style = AppTheme.textStyle.title.large,
                 color = AppTheme.color.title,
+                textAlign = TextAlign.Center
             )
             AnimatedVisibility(
                 visible = earnedPoint != null && earnedPoint != 0,

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
@@ -99,23 +99,16 @@ private fun GuessByPosterContent(
             .fillMaxSize()
             .navigationBarsPadding(),
         bottomBar = {
-            Box(
+            ConfirmButton(
+                title = stringResource(R.string.next),
+                onClick = interactionListener::onMoveToNextQuestion,
+                isEnabled = state.isNextEnabled,
+                isLoading = false,
+                isNegative = false,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                ConfirmButton(
-                    title = stringResource(R.string.next),
-                    onClick = interactionListener::onMoveToNextQuestion,
-                    isEnabled = state.isNextEnabled,
-                    isLoading = false,
-                    isNegative = false,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                )
-            }
+                    .padding(16.dp)
+            )
         }
     ) { innerPadding ->
 

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
@@ -88,23 +88,15 @@ private fun GameScreenContent(
             .fillMaxSize()
             .navigationBarsPadding(),
         bottomBar = {
-            Box(
+            ConfirmButton(
+                title = stringResource(R.string.next),
+                onClick = interactionListener::onMoveToNextQuestion,
+                isEnabled = state.isNextEnabled,
+                isLoading = false,
+                isNegative = false,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                ConfirmButton(
-                    title = stringResource(R.string.next),
-                    onClick = interactionListener::onMoveToNextQuestion,
-                    isEnabled = state.isNextEnabled,
-                    isLoading = false,
-                    isNegative = false,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                )
-            }
+            )
         }
     ) { innerPadding ->
         Box {
@@ -131,7 +123,8 @@ private fun GameScreenContent(
             ) {
                 LazyColumn(
                     modifier = Modifier
-                        .fillMaxSize().statusBarsPadding()
+                        .fillMaxSize()
+                        .statusBarsPadding()
                         .padding(bottom = innerPadding.calculateBottomPadding())
                 ) {
                     item {


### PR DESCRIPTION


# Pull Request Template

## Description
This commit removes a redundant `Box` composable that was wrapping the `ConfirmButton` in `GuessByPosterScreen.kt` and `GuessGenreScreen.kt`.


---

## Changes Made
List the changes introduced in this pull request:

Additionally:
- In `GuessGenreScreen.kt`, adjusted padding for the `ConfirmButton`.
- In `GuessTitle.kt`, centered the title text.

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.