### PR TITLE
Resolve padding problem between title and subtitle in top app bar.

### DIFF
--- a/designSystem/src/main/java/com/amsterdam/designsystem/components/TopAppBar.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/components/TopAppBar.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -42,9 +45,16 @@ fun TopAppBar(
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.height(IntrinsicSize.Min)
         ) {
             leadingIcon?.invoke()
-            Column {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(vertical = 2.dp),
+                verticalArrangement = Arrangement.SpaceBetween,
+                horizontalAlignment = Alignment.Start
+            ) {
                 title?.invoke()
                 subTitle?.invoke()
             }

--- a/designSystem/src/main/java/com/amsterdam/designsystem/theme/textStyle/DefaultTextStyle.kt
+++ b/designSystem/src/main/java/com/amsterdam/designsystem/theme/textStyle/DefaultTextStyle.kt
@@ -123,6 +123,7 @@ internal val defaultTextStyle =
                         fontFamily = nicomoji,
                         fontWeight = FontWeight.Normal,
                         fontSize = 14.sp,
+                        letterSpacing = 0.25.sp,
                         lineHeight = 20.sp,
                     ),
                 medium =


### PR DESCRIPTION

## Description
Resolve padding problem between title and subtitle in top app bar.

---

## Changes Made
- Resolve padding problem between title and sub title in top app bar.

---

## Screenshots (if applicable)

<img width="435" height="405" alt="image" src="https://github.com/user-attachments/assets/eeefc843-e5ec-4b35-8980-f6f69298a9a1" />


---

## Checklist
- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
