### PR TITLE
fix: update plural string format for episodes

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -589,12 +589,12 @@ private fun SeasonHeader(
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = "${season.episodeCount} ${
-                    pluralStringResource(
+                text = pluralStringResource(
                         R.plurals.episodes,
+                        season.episodeCount,
                         season.episodeCount
                     )
-                }",
+                ,
                 color = AppTheme.color.hint,
                 style = AppTheme.textStyle.label.small,
                 modifier = Modifier.padding(end = 4.dp)

--- a/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/seriesDetails/SeriesDetailsScreen.kt
@@ -593,7 +593,7 @@ private fun SeasonHeader(
                         R.plurals.episodes,
                         season.episodeCount,
                         season.episodeCount
-                    )
+                    ).withEnglishDigits()
                 ,
                 color = AppTheme.color.hint,
                 style = AppTheme.textStyle.label.small,

--- a/ui/src/main/res/values-ar/string.xml
+++ b/ui/src/main/res/values-ar/string.xml
@@ -269,10 +269,11 @@
         <item quantity="zero">لا توجد حلقات</item>
         <item quantity="one">حلقة واحدة</item>
         <item quantity="two">حلقتان</item>
-        <item quantity="few">حلقات</item>
-        <item quantity="many">حلقة</item>
-        <item quantity="other">حلقات</item>
+        <item quantity="few">%1$d حلقات</item>
+        <item quantity="many">%1$d حلقة</item>
+        <item quantity="other">%1$d حلقة</item>
     </plurals>
+
     <string name="season">موسم</string>
     <string name="seasons">مواسم</string>
     <string name="country_tour_image_description">صورة جولة في البلد</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -240,8 +240,8 @@
     <string name="rate_message">Select how much you like it</string>
     <string name="add_to_list">Add to list</string>
     <plurals name="episodes">
-        <item quantity="one">%d episode</item>
-        <item quantity="other">%d episodes</item>
+        <item quantity="one">%1$d episode</item>
+        <item quantity="other">%1$d episodes</item>
     </plurals>
     <string name="season">Season</string>
     <string name="seasons">Seasons</string>


### PR DESCRIPTION

# Pull Request Template

## Description
This commit updates the formatting for the "episodes" plural string resource.

---

## Changes Made
List the changes introduced in this pull request:

- In `values/strings.xml`, changed `%d` to `%1$d` for both `one` and `other` quantities.
- In `values-ar/string.xml`, added `%1$d` to `few`, `many`, and `other` quantities.
- In `SeriesDetailsScreen.kt`, updated the usage of `pluralStringResource` to correctly pass the count for formatting.

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.

<img width="1080" height="2400" alt="11111111111111" src="https://github.com/user-attachments/assets/397c78ce-6bdd-4f16-adac-e3ce0c87fb2e" />

---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.