### PR TITLE
Replace LazyColumn with adaptive LazyVerticalGrid

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/categoriesDetails/movies/CategoriesMoviesDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/categoriesDetails/movies/CategoriesMoviesDetailsScreen.kt
@@ -11,18 +11,16 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -93,26 +91,22 @@ private fun CategoriesMoviesDetailsContent(
     interaction: CategoriesMoviesDetailsInteractionListener,
     movies: LazyPagingItems<CategoriesMoviesDetailsUiState.MoviesUiState>
 ) {
-    var appBarHeight by remember { mutableIntStateOf(0) }
-
     Column(
         Modifier
-            .fillMaxSize()
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .padding(horizontal = 16.dp)
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp)
     ) {
         DefaultAppBar(
-            modifier = Modifier
-                .onSizeChanged { appBarHeight = it.height },
             title = stringResource(R.string.movies),
             onNavigateBackClicked = interaction::onClickBack
         )
         Row(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-                .weight(1f),
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+                    .weight(1f),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.Top
         ) {
@@ -151,11 +145,13 @@ private fun CategoriesMoviesDetailsContent(
                 }
 
                 else -> {
-                    LazyColumn(
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(242.dp),
                         modifier = Modifier
-                            .fillMaxHeight()
-                            .weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                .fillMaxHeight()
+                                .weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
                     ) {
                         items(movies.itemCount) { index ->
                             val movie = movies[index] ?: return@items

--- a/ui/src/main/java/com/amsterdam/ui/screens/categoriesDetails/tvShow/CategoriesTvShowsDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/categoriesDetails/tvShow/CategoriesTvShowsDetailsScreen.kt
@@ -12,17 +12,15 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -91,25 +89,22 @@ private fun CategoriesTvShowsDetailsContent(
     interactionListener: CategoriesTvShowsDetailsInteractionListener,
     tvShows: LazyPagingItems<CategoriesTvShowsDetailsUiState.TvShowsUiState>
 ) {
-    var appBarHeight by remember { mutableIntStateOf(0) }
     Box(
         modifier = Modifier
-            .fillMaxSize()
-            .statusBarsPadding()
-            .navigationBarsPadding()
-            .padding(horizontal = 16.dp)
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp)
     ) {
         Column(Modifier.fillMaxSize()) {
             DefaultAppBar(
-                modifier = Modifier
-                    .onSizeChanged { appBarHeight = it.height },
                 title = stringResource(R.string.tv_shows),
                 onNavigateBackClicked = interactionListener::onClickBack
             )
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 12.dp),
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 LazyColumn(
@@ -144,11 +139,13 @@ private fun CategoriesTvShowsDetailsContent(
                     }
 
                     else -> {
-                        LazyColumn(
+                        LazyVerticalGrid(
+                            columns = GridCells.Adaptive(242.dp),
                             modifier = Modifier
-                                .fillMaxHeight()
-                                .weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                                    .fillMaxHeight()
+                                    .weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
                             items(tvShows.itemCount) { index ->
                                 val tvShow = tvShows[index] ?: return@items


### PR DESCRIPTION
## Description
This PR removes the  Categories Details paging source class and updates `CategoriesTvShowsDetailsViewModel` to use a generic `PagingSource` directly for fetching TV shows and Movies by genre. 

This simplifies the paging implementation for TV show details.

---
## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---
## Additional Comments
Additionally, test classes were updated to use a shared `TestExtension` for managing dispatchers, replacing individual `MainDispatcherExtension` instances.