### PR TITLE
fix: fix must login in dialog button width

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/MustLoginDialog.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/MustLoginDialog.kt
@@ -105,7 +105,9 @@ fun MustLoginDialog(
 
             )
             OutlinedButton(
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
                 title = stringResource(R.string.login),
                 onClick = { onClickLogin() },
                 isEnabled = true,


### PR DESCRIPTION
# Pull Request Template

## Description

fillMaxWidth on must login dialog button

---

## Screenshots (if applicable)

Design:

![WhatsApp Image 2025-08-20 at 01 20 56_d75ec3ee](https://github.com/user-attachments/assets/e29ed64a-a5cd-4c2c-9820-e717e8bb262b)



Before:

![WhatsApp Image 2025-08-20 at 01 20 57_095515f7](https://github.com/user-attachments/assets/cc297383-1a01-491a-bee6-5021e4f4cb76)


After:

<img width="481" height="949" alt="image" src="https://github.com/user-attachments/assets/88d81f61-c1ea-4575-ab78-f3af5d801726" />


---

## Checklist
Please ensure the following tasks are completed:

- [x] My code follows the code style of this project
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.