### PR TITLE
fix: remove vertical padding from app bar in MovieDetailsScreen

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/movieDetails/MovieDetailsScreen.kt
@@ -513,7 +513,7 @@ fun MovieContent(
         ) {
             DefaultAppBar(
                 modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .padding(horizontal = 16.dp)
                     .statusBarsPadding()
                     .zIndex(10f),
                 firstOption = if (state.isLoading) null else painterResource(com.amsterdam.designsystem.R.drawable.ic_outlined_star),


### PR DESCRIPTION
This commit removes the `vertical = 8.dp` padding from the `DefaultAppBar` within the `MovieDetailsScreen`. The horizontal padding of `16.dp` remains.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

-
-
-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.