### PR TITLE
fix: adjust app bar padding

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/screens/categories/CategoriesScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/categories/CategoriesScreen.kt
@@ -30,9 +30,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.amsterdam.ui.R
 import com.amsterdam.designsystem.components.TabsLayout
-import com.amsterdam.designsystem.components.Text
 import com.amsterdam.designsystem.theme.AppTheme
 import com.amsterdam.ui.application.LocalNavManager
+import com.amsterdam.ui.components.appBar.DefaultAppBar
 import com.amsterdam.ui.screens.categories.components.CategoryCard
 import com.amsterdam.ui.screens.categoriesDetails.GenreMovieUiModel
 import com.amsterdam.ui.screens.categoriesDetails.GenreTvShowUiModel
@@ -79,17 +79,14 @@ private fun CategoriesScreenContent(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .statusBarsPadding()
             .navigationBarsPadding()
     ) {
-        Column(Modifier.fillMaxSize()) {
-            Text(
+        Column(Modifier.fillMaxSize().statusBarsPadding()) {
+            DefaultAppBar(
                 modifier = Modifier
-                    .padding(vertical = 13.dp, horizontal = 16.dp)
-                    .onSizeChanged { appBarHeight = it.height },
-                text = stringResource(R.string.categories),
-                style = AppTheme.textStyle.title.large,
-                color = AppTheme.color.title
+                    .onSizeChanged { appBarHeight = it.height }.padding(horizontal = 16.dp),
+                title = stringResource(R.string.categories),
+                showNavigateBackButton = false
             )
             TabsLayout(
                 modifier = Modifier

--- a/ui/src/main/java/com/amsterdam/ui/screens/continueWatching/ContinueWatchingScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/continueWatching/ContinueWatchingScreen.kt
@@ -79,7 +79,7 @@ fun ContinueWatchingContent(
             title = stringResource(R.string.recently_watched),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = 16.dp),
             onNavigateBackClicked = interactionListener::onClickBack
         )
 

--- a/ui/src/main/java/com/amsterdam/ui/screens/gameResult/component/GameResultAppBar.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/gameResult/component/GameResultAppBar.kt
@@ -30,7 +30,7 @@ fun GameResultAppBar(
     TopAppBar(
         modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                .padding(horizontal = 16.dp),
         containerColor = Color.Transparent,
         title = {
             Text(

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/character/GuessCharacterScreen.kt
@@ -157,7 +157,7 @@ private fun GameContent(
                                 title = stringResource(R.string.guess_character_game_title),
                                 timerUiState = state.timerUiState,
                                 onCancelGameClick = interactionListener::onCloseButtonClicked,
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                                modifier = Modifier.padding(horizontal = 16.dp),
                             )
 
                             Row(

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessByPoster/GuessByPosterScreen.kt
@@ -170,8 +170,7 @@ private fun GuessByPosterContent(
                             title = topBarTitle,
                             timerUiState = state.timerUiState,
                             modifier = Modifier.padding(
-                                horizontal = 16.dp,
-                                vertical = 8.dp
+                                horizontal = 16.dp
                             ),
                             onCancelGameClick = interactionListener::onCloseButtonClicked
                         )

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/guessGenre/GuessGenreScreen.kt
@@ -152,7 +152,7 @@ private fun GameScreenContent(
                 ) {
                     item {
                         GameTopBar(
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            modifier = Modifier.padding(horizontal = 16.dp),
                             title = stringResource(R.string.genre_game_title),
                             timerUiState = state.timerUiState,
                             onCancelGameClick = interactionListener::onCancelGameClick

--- a/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/games/releaseYear/GuessReleaseYearGameScreen.kt
@@ -154,7 +154,7 @@ private fun GameContent(
                             title = stringResource(R.string.release_game_title),
                             timerUiState = state.timerUiState,
                             onCancelGameClick = interactionListener::onClickClose,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            modifier = Modifier.padding(horizontal = 16.dp),
                         )
 
                         Row(

--- a/ui/src/main/java/com/amsterdam/ui/screens/listDetails/ListDetailsScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/listDetails/ListDetailsScreen.kt
@@ -130,7 +130,7 @@ private fun ListDetailsContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .onSizeChanged { headerHeight = with(density) { it.height.dp } }
-                .padding(start = 16.dp, end = 16.dp, top = 8.dp),
+                .padding(horizontal = 16.dp),
             lastOption = painterResource(com.amsterdam.designsystem.R.drawable.ic_delete),
             lastOptionIconTint = AppTheme.color.redAccent,
             onLastOptionClicked = interactionListener::onClickDeleteList,

--- a/ui/src/main/java/com/amsterdam/ui/screens/profile/components/LoggedInContent.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/profile/components/LoggedInContent.kt
@@ -68,7 +68,7 @@ fun LoggedInContent(
         ) {
             LazyColumn(
                 modifier = Modifier
-                    .fillMaxSize(),
+                    .fillMaxSize().statusBarsPadding(),
                 state = lazyListState,
                 contentPadding = PaddingValues(bottom = 40.dp)
             ) {
@@ -115,7 +115,7 @@ fun LoggedInContent(
                     color = AppTheme.color.title,
                     modifier = Modifier
                         .statusBarsPadding()
-                        .padding(horizontal = 16.dp, vertical = 13.dp)
+                        .padding(horizontal = 16.dp)
                 )
             },
             modifier = Modifier.background(appBarColor)

--- a/ui/src/main/java/com/amsterdam/ui/screens/topRated/TopRatedScreen.kt
+++ b/ui/src/main/java/com/amsterdam/ui/screens/topRated/TopRatedScreen.kt
@@ -118,7 +118,7 @@ private fun TopRatedContent(
 
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxSize().statusBarsPadding()
         ) {
             DefaultAppBar(
                 title = stringResource(R.string.top_rating),
@@ -126,7 +126,7 @@ private fun TopRatedContent(
                     .fillMaxWidth()
                     .background(appBarColor)
                     .statusBarsPadding()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .padding(horizontal = 16.dp)
                     .onSizeChanged { headerHeight = with(density) { it.height.dp } },
                 onNavigateBackClicked = interactionListener::onClickBack
             )


### PR DESCRIPTION
This commit removes the vertical padding from the app bars across multiple screens to improve visual consistency.

Specifically, the following screens have had their app bar vertical padding removed:
- TopRatedScreen
- GuessByPosterScreen
- ListDetailsScreen
- CategoriesScreen
- GuessGenreScreen
- GuessCharacterScreen
- GuessReleaseYearGameScreen
- LoggedInContent (Profile screen component)
- ContinueWatchingScreen
- GameResultAppBar (Game result screen component)

Additionally, status bar padding has been applied to the main content Column in TopRatedScreen and CategoriesScreen, and LoggedInContent.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

-
-
-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.