### PR TITLE
refactor: Center title in DefaultAppBar

### DIFF
--- a/ui/src/main/java/com/amsterdam/ui/components/appBar/DefaultAppBar.kt
+++ b/ui/src/main/java/com/amsterdam/ui/components/appBar/DefaultAppBar.kt
@@ -1,7 +1,10 @@
 package com.amsterdam.ui.components.appBar
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
@@ -41,13 +44,15 @@ fun DefaultAppBar(
         title =
             title.takeIf { it.isNotBlank() }?.let { text ->
                 {
-                    Text(
-                        text = text,
-                        color = AppTheme.color.title,
-                        style = AppTheme.textStyle.title.large,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    Box(Modifier.height(40.dp), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = text,
+                            color = AppTheme.color.title,
+                            style = AppTheme.textStyle.title.large,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
             },
         leadingIcon =
@@ -99,6 +104,18 @@ private fun DefaultAppBarPreview() {
             firstOption = painterResource(com.amsterdam.designsystem.R.drawable.ic_outlined_star),
             lastOption = painterResource(com.amsterdam.designsystem.R.drawable.ic_outlined_add_to_favourite),
             containerColor = AppTheme.color.surface,
+        )
+    }
+}
+
+@ThemeAndLocalePreviews
+@Composable
+private fun DefaultAppBaarPreview() {
+    AflamiTheme {
+        DefaultAppBar(
+            title = stringResource(R.string.my_account),
+            containerColor = AppTheme.color.surface,
+            showNavigateBackButton = false
         )
     }
 }


### PR DESCRIPTION
This commit modifies the `DefaultAppBar` composable to center the title text vertically. The title `Text` is now wrapped in a `Box` with a fixed height and `contentAlignment = Alignment.Center`.

Additionally, a preview for `DefaultAppBar` is added.

# Pull Request Template

## Description
Provide a clear and concise description of what this pull request does. Include the purpose and context for the changes.

---

## Changes Made
List the changes introduced in this pull request:

-
-
-

---

## Screenshots (if applicable)
Include screenshots or GIFs to showcase the changes, especially if they impact the UI.


---

## Checklist
Please ensure the following tasks are completed:

- [ ] My code follows the code style of this project
- [ ] Changes have been tested manually and verified.
- [ ] PR includes at most one single feature.

---

## Additional Comments
Add any additional information or context about the pull request here.